### PR TITLE
Nearest query now handles custom distances

### DIFF
--- a/api-application/build.gradle
+++ b/api-application/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'org.springframework.boot'
 
 ext {
     set('springCloudVersion', '2020.0.2')
+    set('uomVersion', '2.0.2')
 }
 
 dependencyManagement {
@@ -40,6 +41,11 @@ dependencies {
     implementation 'de.grundid.opendatalab:geojson-jackson:1.14'
     implementation 'org.hibernate:hibernate-spatial'
 
+    // Unit conversion
+    implementation 'tech.units:indriya:2.1.2'
+    implementation "systems.uom:systems-common:${uomVersion}"
+    implementation "systems.uom:systems-unicode:${uomVersion}"
+    implementation "systems.uom:systems-quantity:${uomVersion}"
 
     // FHIR
     implementation "ca.uhn.hapi.fhir:hapi-fhir-spring-boot-starter:${hapiVersion}"

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/models/NearestQuery.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/models/NearestQuery.java
@@ -1,0 +1,90 @@
+package gov.usds.vaccineschedule.api.models;
+
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
+import systems.uom.unicode.CLDR;
+import tech.units.indriya.format.SimpleUnitFormat;
+import tech.units.indriya.quantity.Quantities;
+
+import javax.measure.MetricPrefix;
+import javax.measure.Quantity;
+import javax.measure.Unit;
+import javax.measure.format.MeasurementParseException;
+import javax.measure.quantity.Length;
+import java.io.Serializable;
+
+import static tech.units.indriya.unit.Units.METRE;
+
+/**
+ * Created by nickrobison on 4/1/21
+ */
+public class NearestQuery implements Serializable {
+
+
+    private static final long serialVersionUID = 42L;
+    private static final Unit<Length> KM = MetricPrefix.KILO(METRE);
+    private static final String NUMBER_EXN_FORMAT = "Cannot parse: `%s` as coordinate.";
+
+    private final Quantity<Length> distance;
+    private final Point point;
+
+
+    private NearestQuery(Quantity<Length> distance, Point point) {
+        this.distance = distance;
+        this.point = point;
+    }
+
+    public Point getPoint() {
+        return point;
+    }
+
+    public Quantity<Length> getDistance() {
+        return distance;
+    }
+
+    public static NearestQuery fromToken(String param) {
+        // FHIR defines the query as [latitude]|[longitude]|[distance]|[units]
+        final String[] split = param.split("\\|");
+        if (split.length < 2) {
+            throw new IllegalArgumentException("Query must have lat/lon");
+        }
+        final double lon, lat;
+        try {
+            lon = Double.parseDouble(split[1]);
+            lat = Double.parseDouble(split[0]);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(String.format(NUMBER_EXN_FORMAT, e.getMessage()));
+        }
+        final GeometryFactory factory = new GeometryFactory(new PrecisionModel(), 4326);
+        final Point point = factory.createPoint(new Coordinate(lon, lat));
+
+        if (split.length >= 4) {
+            final double distance;
+            try {
+                distance = Double.parseDouble(split[2]);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException(String.format(NUMBER_EXN_FORMAT, e.getMessage()));
+            }
+
+            // Indriya doesn't have built-in support for english units (e.g. miles), so we need a hack
+            if (split[3].equals("mi")) {
+                return new NearestQuery(Quantities.getQuantity(distance, CLDR.MILE), point);
+            }
+            try {
+                final Unit<Length> unit = SimpleUnitFormat.getInstance().parse(split[3]).asType(Length.class);
+                return new NearestQuery(Quantities.getQuantity(distance, unit), point);
+            } catch (MeasurementParseException e) {
+                throw new IllegalArgumentException(String.format("Unsupported unit: %s", e.getParsedString()));
+            }
+
+
+        } else if (split.length == 3) {
+            final double distance = Double.parseDouble(split[2]);
+            return new NearestQuery(Quantities.getQuantity(distance, KM), point);
+        }
+
+        return new NearestQuery(Quantities.getQuantity(10, KM), point);
+    }
+}

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/providers/LocationProvider.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/providers/LocationProvider.java
@@ -9,13 +9,10 @@ import ca.uhn.fhir.rest.annotation.Search;
 import ca.uhn.fhir.rest.param.StringParam;
 import ca.uhn.fhir.rest.param.TokenParam;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
+import gov.usds.vaccineschedule.api.models.NearestQuery;
 import gov.usds.vaccineschedule.api.services.LocationService;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r4.model.Location;
-import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.GeometryFactory;
-import org.locationtech.jts.geom.Point;
-import org.locationtech.jts.geom.PrecisionModel;
 import org.springframework.stereotype.Component;
 
 import java.util.Collection;
@@ -42,10 +39,8 @@ public class LocationProvider extends AbstractJaxRsResourceProvider<Location> {
             @OptionalParam(name = Location.SP_ADDRESS_STATE) StringParam state) {
         // If we have a nearestParam, do that, rather than anything else
         if (nearestParam != null) {
-            final String[] values = nearestParam.getValue().split("\\|");
-            final GeometryFactory factory = new GeometryFactory(new PrecisionModel(), 4326);
-            final Point point = factory.createPoint(new Coordinate(Double.parseDouble(values[1]), Double.parseDouble(values[0])));
-            return this.service.findByLocation(point);
+            final NearestQuery query = NearestQuery.fromToken(nearestParam.getValue());
+            return this.service.findByLocation(query);
         } else {
             return service.findLocations(identifier, city, state);
         }

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/repositories/LocationRepository.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/repositories/LocationRepository.java
@@ -20,9 +20,9 @@ import java.util.UUID;
 public interface LocationRepository extends CrudRepository<LocationEntity, UUID>, JpaSpecificationExecutor<LocationEntity> {
 
     @Query(
-            "from LocationEntity l where distance(l.coordinates, :location) < 50000"
+            "from LocationEntity l where distance(l.coordinates, :location) < :distance"
     )
-    List<LocationEntity> locationsWithinDistance(Point location);
+    List<LocationEntity> locationsWithinDistance(Point location, double distance);
 
     static Specification<LocationEntity> hasIdentifier(String system, String value) {
         return (root, cq, cb) -> {

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/services/LocationService.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/services/LocationService.java
@@ -3,6 +3,7 @@ package gov.usds.vaccineschedule.api.services;
 import ca.uhn.fhir.rest.param.StringParam;
 import ca.uhn.fhir.rest.param.TokenParam;
 import gov.usds.vaccineschedule.api.db.models.LocationEntity;
+import gov.usds.vaccineschedule.api.models.NearestQuery;
 import gov.usds.vaccineschedule.api.repositories.LocationRepository;
 import gov.usds.vaccineschedule.api.services.geocoder.GeocoderService;
 import org.hl7.fhir.instance.model.api.IIdType;
@@ -26,6 +27,7 @@ import static gov.usds.vaccineschedule.api.repositories.LocationRepository.hasId
 import static gov.usds.vaccineschedule.api.repositories.LocationRepository.inCity;
 import static gov.usds.vaccineschedule.api.repositories.LocationRepository.inState;
 import static gov.usds.vaccineschedule.api.services.ServiceHelpers.fromIterable;
+import static tech.units.indriya.unit.Units.METRE;
 
 /**
  * Created by nickrobison on 3/26/21
@@ -99,8 +101,9 @@ public class LocationService {
     }
 
     @Transactional
-    public Collection<Location> findByLocation(Point point) {
-        return fromIterable(() -> this.repo.locationsWithinDistance(point), LocationEntity::toFHIR);
+    public Collection<Location> findByLocation(NearestQuery point) {
+        final double distance = point.getDistance().to(METRE).getValue().doubleValue();
+        return fromIterable(() -> this.repo.locationsWithinDistance(point.getPoint(), distance), LocationEntity::toFHIR);
     }
 
 

--- a/api-application/src/test/java/gov/usds/vaccineschedule/api/models/NearestQueryTest.java
+++ b/api-application/src/test/java/gov/usds/vaccineschedule/api/models/NearestQueryTest.java
@@ -1,0 +1,60 @@
+package gov.usds.vaccineschedule.api.models;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static tech.units.indriya.unit.Units.METRE;
+
+/**
+ * Created by nickrobison on 4/1/21
+ */
+public class NearestQueryTest {
+
+    @Test
+    public void testValidQueries() {
+        // Just the point
+        final NearestQuery single = NearestQuery.fromToken("42.4887|-71.2837");
+        assertAll(() -> assertEquals(-71.2837, single.getPoint().getX(), "Should have point"),
+                () -> assertEquals(10000, convertToMeters(single), "Should converted distance"));
+
+        // With custom distance
+        final NearestQuery distance = NearestQuery.fromToken("42.4887|-71.2837|50");
+        assertAll(() -> assertEquals(-71.2837, distance.getPoint().getX(), "Should have point"),
+                () -> assertEquals(50000, convertToMeters(distance), "Should converted distance"));
+
+        // With custom units
+        final NearestQuery km = NearestQuery.fromToken("42.4887|-71.2837|50|km");
+        assertAll(() -> assertEquals(-71.2837, km.getPoint().getX(), "Should have point"),
+                () -> assertEquals(50000, convertToMeters(km), "Should converted distance"));
+
+        final NearestQuery miles = NearestQuery.fromToken("42.4887|-71.2837|50|mi");
+        assertAll(() -> assertEquals(-71.2837, miles.getPoint().getX(), "Should have point"),
+                () -> assertEquals(80467.2, convertToMeters(miles), "Should converted distance"));
+    }
+
+
+    @Test
+    public void testInvalidQueries() {
+        assertThrows(IllegalArgumentException.class, () -> NearestQuery.fromToken(""), "Should throw with no data");
+        assertThrows(IllegalArgumentException.class, () -> NearestQuery.fromToken("452|"), "Should throw with no data");
+
+        // Test incorrect unit
+        final IllegalArgumentException exn = assertThrows(IllegalArgumentException.class, () -> NearestQuery.fromToken("42.4887|-71.2837|50|inch"), "Should throw with inches");
+        assertEquals("Unsupported unit: inch not recognized (in inch at index 0)", exn.getMessage(), "Should have correct message");
+
+        // Test with bad coordinates
+        final IllegalArgumentException badCoords = assertThrows(IllegalArgumentException.class, () -> NearestQuery.fromToken("42.4887|bad"), "Should throw with non-double coordinate");
+        assertEquals("Cannot parse: `For input string: \"bad\"` as coordinate.", badCoords.getMessage(), "Should have correct message");
+
+        // Test with bad distance
+        final IllegalArgumentException badDistance = assertThrows(IllegalArgumentException.class, () -> NearestQuery.fromToken("42.4887|-71.2837|bad|mi"), "Should throw with bad distance");
+        assertEquals("Cannot parse: `For input string: \"bad\"` as coordinate.", badDistance.getMessage(), "Should have correct error message");
+
+    }
+
+    public static double convertToMeters(NearestQuery query) {
+        return query.getDistance().to(METRE).getValue().doubleValue();
+    }
+}

--- a/api-application/src/test/java/gov/usds/vaccineschedule/api/providers/LocationProviderTest.java
+++ b/api-application/src/test/java/gov/usds/vaccineschedule/api/providers/LocationProviderTest.java
@@ -37,7 +37,7 @@ public class LocationProviderTest extends BaseApplicationTest {
     public void testLocationSearch() {
         final IGenericClient client = provideFhirClient();
         Map<String, List<IQueryParameterType>> params = new HashMap<>();
-        params.put("near", List.of(new TokenParam().setValue("42.4887|-71.2837")));
+        params.put("near", List.of(new TokenParam().setValue("42.4887|-71.2837|50")));
 
         final Bundle results = client.search()
                 .forResource(Location.class)


### PR DESCRIPTION
Improved handling of token param parsing for the location provider.
We're now using a custom class for holding the intersection point and the distance.
Using javax measure we can convert between various units, but we need special handling for miles. Go figure.

closes #14 