### PR TITLE
Return absolute resource URLs from the publisher

### DIFF
--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/services/SourceFetchService.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/services/SourceFetchService.java
@@ -74,7 +74,6 @@ public class SourceFetchService {
         final WebClient client = WebClient.create(source);
         client.get()
                 .uri("/$bulk-publish")
-                .accept(MediaType.parseMediaType("application/fhir+ndjson"))
                 .retrieve()
                 .bodyToMono(PublishResponse.class)
                 .flatMapMany(response -> Flux.fromIterable(response.getOutput())
@@ -84,7 +83,7 @@ public class SourceFetchService {
                         // We can hack this by grouping and sorting, since they happen to be in alphabetical order
                         .sort(Comparator.comparing(GroupedFlux::key))
                         .flatMap(group -> group
-                                .flatMap(url -> client.get().uri("data" + url.getUrl()).retrieve().bodyToMono(DataBuffer.class))
+                                .flatMap(url -> client.get().uri(url.getUrl()).accept(MediaType.parseMediaType("application/fhir+ndjson")).retrieve().bodyToMono(DataBuffer.class))
                                 .flatMap(body -> Flux.fromIterable(converter.inputStreamToResource(body.asInputStream(true))))))
                 .onErrorContinue((error) -> error instanceof WebClientException,
                         (throwable, o) -> { // If we throw an exception

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,8 @@ services:
       dockerfile: publisher-application/Dockerfile
     image: vs-publisher
     command: bootRun
+    environment:
+      SPRING_PROFILES_ACTIVE: dockerized
     ports:
       - "${VS_PUBLISHER_PORT:-9090}:9090"
   api:

--- a/publisher-application/src/main/java/gov/usds/vaccineschedule/publisher/SchedulePublisherApplication.java
+++ b/publisher-application/src/main/java/gov/usds/vaccineschedule/publisher/SchedulePublisherApplication.java
@@ -1,12 +1,15 @@
 package gov.usds.vaccineschedule.publisher;
 
+import gov.usds.vaccineschedule.publisher.config.PublisherConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 /**
  * Created by nickrobison on 3/25/21
  */
 @SpringBootApplication
+@EnableConfigurationProperties({PublisherConfig.class})
 public class SchedulePublisherApplication {
 
     public static void main(String[] args) {

--- a/publisher-application/src/main/java/gov/usds/vaccineschedule/publisher/config/PublisherConfig.java
+++ b/publisher-application/src/main/java/gov/usds/vaccineschedule/publisher/config/PublisherConfig.java
@@ -1,0 +1,22 @@
+package gov.usds.vaccineschedule.publisher.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+/**
+ * Created by nickrobison on 4/6/21
+ */
+@ConfigurationProperties(prefix = "publisher")
+public class PublisherConfig {
+
+    private final String baseUrl;
+
+    @ConstructorBinding
+    public PublisherConfig(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+
+    public String getBaseURL() {
+        return baseUrl;
+    }
+}

--- a/publisher-application/src/main/java/gov/usds/vaccineschedule/publisher/providers/PublishProvider.java
+++ b/publisher-application/src/main/java/gov/usds/vaccineschedule/publisher/providers/PublishProvider.java
@@ -1,5 +1,6 @@
 package gov.usds.vaccineschedule.publisher.providers;
 
+import gov.usds.vaccineschedule.publisher.config.PublisherConfig;
 import gov.usds.vaccineschedule.publisher.models.PublishResponse;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -13,14 +14,20 @@ import java.util.List;
 @RestController
 public class PublishProvider {
 
+    private final PublisherConfig config;
+
+    public PublishProvider(PublisherConfig config) {
+        this.config = config;
+    }
+
 
     @RequestMapping("$bulk-publish")
     public PublishResponse publish() {
         // Create some dummy data for each resource type
         final List<PublishResponse.OutputEntry> output = List.of(
-                new PublishResponse.OutputEntry("Schedule", "/test-schedule.ndjson"),
-                new PublishResponse.OutputEntry("Location", "/test-location.ndjson"),
-                new PublishResponse.OutputEntry("Slot", "/test-slot.ndjson")
+                new PublishResponse.OutputEntry("Schedule", buildURL("/test-schedule.ndjson")),
+                new PublishResponse.OutputEntry("Location", buildURL("/test-location.ndjson")),
+                new PublishResponse.OutputEntry("Slot", buildURL("/test-slot.ndjson"))
         );
 
         final PublishResponse publishResponse = new PublishResponse();
@@ -29,5 +36,9 @@ public class PublishProvider {
         publishResponse.setOutput(output);
 
         return publishResponse;
+    }
+
+    private String buildURL(String resource) {
+        return String.format("%s/data%s", this.config.getBaseURL(), resource);
     }
 }

--- a/publisher-application/src/main/resources/application-dockerized.yml
+++ b/publisher-application/src/main/resources/application-dockerized.yml
@@ -1,0 +1,2 @@
+publisher:
+  base-url: http://publisher:${server.port}

--- a/publisher-application/src/main/resources/application.yml
+++ b/publisher-application/src/main/resources/application.yml
@@ -18,3 +18,5 @@ hapi:
 logging:
   level:
     ca.uhn.fhir.jaxrs: debug
+publisher:
+  base-url: http://localhost:${server.port}

--- a/publisher-application/src/test/java/gov/usds/vaccineschedule/publisher/integration/PublisherTests.java
+++ b/publisher-application/src/test/java/gov/usds/vaccineschedule/publisher/integration/PublisherTests.java
@@ -62,7 +62,7 @@ public class PublisherTests extends BaseApplicationTest {
 
         final HttpEntity<Object> entity = new HttpEntity<>(httpHeaders);
         final ResponseEntity<String> ndjson = template
-                .exchange("/data/" + o.getUrl(), HttpMethod.GET, entity, String.class);
+                .exchange(o.getUrl(), HttpMethod.GET, entity, String.class);
         assertAll(() -> assertEquals(HttpStatus.OK, ndjson.getStatusCode()),
                 () -> assertNotNull(ndjson.getBody()));
         assertNotNull(ndjson, "Should have response");

--- a/publisher-application/src/test/java/gov/usds/vaccineschedule/publisher/utils/BaseApplicationTest.java
+++ b/publisher-application/src/test/java/gov/usds/vaccineschedule/publisher/utils/BaseApplicationTest.java
@@ -7,7 +7,7 @@ import org.springframework.boot.web.server.LocalServerPort;
 /**
  * Created by nickrobison on 4/6/21
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @AutoConfigureMockMvc
 public class BaseApplicationTest {
     @LocalServerPort

--- a/publisher-application/src/test/resources/application-default.yml
+++ b/publisher-application/src/test/resources/application-default.yml
@@ -1,0 +1,2 @@
+server:
+  port: 7777


### PR DESCRIPTION
Update the publisher to return absolute URLs, based on the the new `baseUrl` configuration parameter.

The API service now uses those urls, rather than constructing its own.

Closes #25 