### PR TITLE
Update LocationProvider to support searching for locations by zipcode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ curl --location --request GET 'http://localhost:8080/fhir/Location?address-city=
 --header 'Content-Type: application/fhir+json'
 ```
 
+Supported address search parameters are:
+
+- City
+- State
+- Postalcode
+
 or within a certain radius:
 
 ```bash

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/providers/LocationProvider.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/providers/LocationProvider.java
@@ -44,6 +44,7 @@ public class LocationProvider extends AbstractPaginatingProvider<Location> {
             @OptionalParam(name = Location.SP_IDENTIFIER) TokenParam identifier,
             @OptionalParam(name = Location.SP_ADDRESS_CITY) StringParam city,
             @OptionalParam(name = Location.SP_ADDRESS_STATE) StringParam state,
+            @OptionalParam(name = Location.SP_ADDRESS_POSTALCODE) StringParam postalCode,
             RequestDetails requestDetails,
             @Offset Integer pageOffset,
             @Count Integer pageSize) {
@@ -58,8 +59,8 @@ public class LocationProvider extends AbstractPaginatingProvider<Location> {
             totalCount = this.service.countByLocation(query);
             locations = this.service.findByLocation(query, pageRequest);
         } else {
-            totalCount = this.service.countLocations(identifier, city, state);
-            locations = service.findLocations(identifier, city, state, pageRequest);
+            totalCount = this.service.countLocations(identifier, city, state, postalCode);
+            locations = service.findLocations(identifier, city, state, postalCode, pageRequest);
         }
 
         return super.createBundle(requestDetails, locations, searchTime, pageRequest, totalCount);

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/repositories/LocationRepository.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/repositories/LocationRepository.java
@@ -47,4 +47,8 @@ public interface LocationRepository extends JpaRepository<LocationEntity, UUID>,
     static Specification<LocationEntity> inState(String state) {
         return (root, cq, cb) -> cb.equal(root.get(LocationEntity_.address).get(AddressElement_.state), state);
     }
+
+    static Specification<LocationEntity> inPostalCode(String postalCode) {
+        return (root, cq, cb) -> cb.equal(root.get(LocationEntity_.address).get(AddressElement_.postalCode), postalCode);
+    }
 }

--- a/api-application/src/test/java/gov/usds/vaccineschedule/api/providers/LocationProviderTest.java
+++ b/api-application/src/test/java/gov/usds/vaccineschedule/api/providers/LocationProviderTest.java
@@ -85,7 +85,7 @@ public class LocationProviderTest extends BaseApplicationTest {
     }
 
     @Test
-    void cityStateQuery() {
+    void cityStatePostalQuery() {
         final IGenericClient client = provideFhirClient();
         // Look for all by state
 
@@ -136,5 +136,16 @@ public class LocationProviderTest extends BaseApplicationTest {
                 .execute();
 
         assertEquals(0, wrongCity.getEntry().size(), "Should have a single location");
+
+        // Search for locations by zipcode
+        final Bundle postalCode = client
+                .search()
+                .forResource(Location.class)
+                .where(Location.ADDRESS_POSTALCODE.matchesExactly().value("02740"))
+                .returnBundle(Bundle.class)
+                .encodedJson()
+                .execute();
+
+        assertEquals(1, postalCode.getTotal(), "Should have a single location");
     }
 }


### PR DESCRIPTION
Allow users to find locations based on a given zip code.

This doesn't really support radiuses right now, we'll need to figure out how to extend the `near` query to say 'find me a location within 50 miles of my zip code`.

That will also require updating our geocoded code to support reverse geocoding zip codes as well.

closes #31 