### PR TITLE
Add support for updating existing entities

### DIFF
--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/db/models/AbstractIdentifierEntity.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/db/models/AbstractIdentifierEntity.java
@@ -7,6 +7,7 @@ import javax.persistence.Column;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.MappedSuperclass;
+import java.util.Objects;
 
 /**
  * Created by nickrobison on 3/26/21
@@ -53,5 +54,18 @@ public class AbstractIdentifierEntity<T> extends BaseEntity {
         return new Identifier()
                 .setSystem(this.system)
                 .setValue(this.value);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AbstractIdentifierEntity<?> that = (AbstractIdentifierEntity<?>) o;
+        return system.equals(that.system) && value.equals(that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(system, value);
     }
 }

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/db/models/BaseEntity.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/db/models/BaseEntity.java
@@ -38,6 +38,10 @@ public abstract class BaseEntity {
         return internalId;
     }
 
+    public void setInternalId(UUID internalId) {
+        this.internalId = internalId;
+    }
+
     public OffsetDateTime getCreatedAt() {
         return createdAt;
     }

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/db/models/Constants.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/db/models/Constants.java
@@ -1,8 +1,0 @@
-package gov.usds.vaccineschedule.api.db.models;
-
-/**
- * Created by nickrobison on 3/26/21
- */
-public class Constants {
-    public static String ORIGINAL_ID_SYSTEM = "http://usds.gov/vaccine/source-identifier";
-}

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/db/models/LocationIdentifier.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/db/models/LocationIdentifier.java
@@ -20,6 +20,7 @@ public class LocationIdentifier extends AbstractIdentifierEntity<LocationEntity>
         // Hibernate required
     }
 
+
     public static LocationIdentifier fromFHIR(Identifier resource) {
         return new LocationIdentifier(resource.getSystem(), resource.getValue());
     }

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/db/models/ScheduleEntity.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/db/models/ScheduleEntity.java
@@ -14,7 +14,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static gov.usds.vaccineschedule.api.db.models.Constants.ORIGINAL_ID_SYSTEM;
+import static gov.usds.vaccineschedule.common.Constants.ORIGINAL_ID_SYSTEM;
 
 /**
  * Created by nickrobison on 3/26/21
@@ -65,6 +65,13 @@ public class ScheduleEntity extends BaseEntity implements Flammable<Schedule> {
         schedule.addActor(new Reference("Location/" + this.location.getInternalId().toString()));
 
         return schedule;
+    }
+
+    public void merge(ScheduleEntity other) {
+        this.identifiers.forEach(i -> i.setEntity(null));
+        this.identifiers.clear();
+        this.identifiers.addAll(other.identifiers);
+        this.identifiers.forEach(i -> i.setEntity(this));
     }
 
     public static ScheduleEntity fromFHIR(LocationEntity location, Schedule resource) {

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/db/models/SlotEntity.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/db/models/SlotEntity.java
@@ -24,7 +24,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static gov.usds.vaccineschedule.api.db.models.Constants.ORIGINAL_ID_SYSTEM;
+import static gov.usds.vaccineschedule.common.Constants.ORIGINAL_ID_SYSTEM;
 
 /**
  * Created by nickrobison on 3/29/21
@@ -148,6 +148,20 @@ public class SlotEntity extends BaseEntity implements Flammable<VaccineSlot> {
         slot.setCapacity(new IntegerType(capacity));
 
         return slot;
+    }
+
+    public void merge(SlotEntity other) {
+        this.bookingPhone = other.bookingPhone;
+        this.bookingUrl = other.bookingUrl;
+        this.capacity = other.capacity;
+        this.status = other.status;
+        this.startTime = other.startTime;
+        this.endTime = other.endTime;
+
+        this.identifiers.forEach(i -> i.setEntity(null));
+        this.identifiers.clear();
+        this.identifiers.addAll(other.identifiers);
+        this.identifiers.forEach(i -> i.setEntity(this));
     }
 
     public static SlotEntity fromFHIR(ScheduleEntity schedule, VaccineSlot resource) {

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/repositories/LocationRepository.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/repositories/LocationRepository.java
@@ -13,7 +13,7 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
-import javax.persistence.criteria.CollectionJoin;
+import javax.persistence.criteria.SetJoin;
 import java.util.List;
 import java.util.UUID;
 
@@ -32,7 +32,8 @@ public interface LocationRepository extends JpaRepository<LocationEntity, UUID>,
 
     static Specification<LocationEntity> hasIdentifier(String system, String value) {
         return (root, cq, cb) -> {
-            final CollectionJoin<LocationEntity, LocationIdentifier> idJoin = root.join(LocationEntity_.identifiers);
+
+            final SetJoin<LocationEntity, LocationIdentifier> idJoin = root.join(LocationEntity_.identifiers);
 
             return cb.and(
                     cb.equal(idJoin.get(LocationIdentifier_.system), system),

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/repositories/SlotRepository.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/repositories/SlotRepository.java
@@ -10,9 +10,9 @@ import gov.usds.vaccineschedule.api.db.models.ScheduleIdentifier_;
 import gov.usds.vaccineschedule.api.db.models.SlotEntity;
 import gov.usds.vaccineschedule.api.db.models.SlotEntity_;
 import gov.usds.vaccineschedule.api.db.models.SlotIdentifier;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 import javax.persistence.criteria.CollectionJoin;
@@ -29,11 +29,7 @@ import java.util.UUID;
 import java.util.function.BiFunction;
 
 @Repository
-public interface SlotRepository extends JpaRepository<SlotEntity, UUID> {
-
-    List<SlotEntity> findAll(Specification<SlotEntity> searchSpec, Pageable p);
-
-    List<SlotEntity> findAll(Specification<SlotEntity> searchSpec);
+public interface SlotRepository extends JpaRepository<SlotEntity, UUID>, JpaSpecificationExecutor<SlotEntity> {
 
     long count(Specification<SlotEntity> searchSpec);
 

--- a/api-application/src/test/java/gov/usds/vaccineschedule/api/providers/LocationProviderTest.java
+++ b/api-application/src/test/java/gov/usds/vaccineschedule/api/providers/LocationProviderTest.java
@@ -13,8 +13,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static gov.usds.vaccineschedule.api.db.models.Constants.ORIGINAL_ID_SYSTEM;
 import static gov.usds.vaccineschedule.api.utils.FhirHandlers.unwrapBundle;
+import static gov.usds.vaccineschedule.common.Constants.ORIGINAL_ID_SYSTEM;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/api-application/src/test/java/gov/usds/vaccineschedule/api/providers/ScheduleProviderTest.java
+++ b/api-application/src/test/java/gov/usds/vaccineschedule/api/providers/ScheduleProviderTest.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import static gov.usds.vaccineschedule.api.db.models.Constants.ORIGINAL_ID_SYSTEM;
+import static gov.usds.vaccineschedule.common.Constants.ORIGINAL_ID_SYSTEM;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/api-application/src/test/java/gov/usds/vaccineschedule/api/providers/SlotProviderTest.java
+++ b/api-application/src/test/java/gov/usds/vaccineschedule/api/providers/SlotProviderTest.java
@@ -13,8 +13,8 @@ import org.junit.jupiter.api.Test;
 import java.sql.Date;
 import java.util.List;
 
-import static gov.usds.vaccineschedule.api.db.models.Constants.ORIGINAL_ID_SYSTEM;
 import static gov.usds.vaccineschedule.api.utils.FhirHandlers.unwrapBundle;
+import static gov.usds.vaccineschedule.common.Constants.ORIGINAL_ID_SYSTEM;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/api-application/src/test/java/gov/usds/vaccineschedule/api/services/FetchServiceTest.java
+++ b/api-application/src/test/java/gov/usds/vaccineschedule/api/services/FetchServiceTest.java
@@ -5,7 +5,6 @@ import ca.uhn.fhir.validation.FhirValidator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.usds.vaccineschedule.api.BaseApplicationTest;
 import gov.usds.vaccineschedule.api.config.ScheduleSourceConfig;
-import gov.usds.vaccineschedule.api.repositories.LocationRepository;
 import gov.usds.vaccineschedule.common.models.PublishResponse;
 import gov.usds.vaccineschedule.common.models.VaccineSlot;
 import okhttp3.mockwebserver.MockResponse;
@@ -55,7 +54,7 @@ public class FetchServiceTest extends BaseApplicationTest {
     private ObjectMapper mapper;
     @Autowired
     private FhirValidator validator;
-    private LocationRepository lRepo;
+    private LocationService lService;
     private ScheduleService scheduleService;
     private SlotService slotService;
     private SourceFetchService service;
@@ -76,16 +75,16 @@ public class FetchServiceTest extends BaseApplicationTest {
     @BeforeEach
     void setupFetchService() {
         baseUrl = String.format("http://localhost:%s", mockWebServer.getPort());
-        lRepo = Mockito.mock(LocationRepository.class);
+        lService = Mockito.mock(LocationService.class);
         scheduleService = Mockito.mock(ScheduleService.class);
         slotService = Mockito.mock(SlotService.class);
         final ScheduleSourceConfig config = new ScheduleSourceConfig(false, List.of(baseUrl), Collections.emptyList(), TimeZone.getDefault());
-        service = new SourceFetchService(ctx, config, lRepo, scheduleService, slotService, validator);
+        service = new SourceFetchService(ctx, config, lService, scheduleService, slotService, validator);
     }
 
     @AfterEach
     void restTheMocks() {
-        Mockito.reset(lRepo, scheduleService, slotService);
+        Mockito.reset(lService, scheduleService, slotService);
     }
 
     @Test

--- a/api-application/src/test/java/gov/usds/vaccineschedule/api/services/TestLocationSearch.java
+++ b/api-application/src/test/java/gov/usds/vaccineschedule/api/services/TestLocationSearch.java
@@ -1,7 +1,0 @@
-package gov.usds.vaccineschedule.api.services;
-
-/**
- * Created by nickrobison on 3/30/21
- */
-public class TestLocationSearch {
-}

--- a/api-application/src/test/java/gov/usds/vaccineschedule/api/services/TestLocationService.java
+++ b/api-application/src/test/java/gov/usds/vaccineschedule/api/services/TestLocationService.java
@@ -1,0 +1,55 @@
+package gov.usds.vaccineschedule.api.services;
+
+import ca.uhn.fhir.parser.IParser;
+import ca.uhn.fhir.rest.param.TokenParam;
+import gov.usds.vaccineschedule.api.BaseApplicationTest;
+import gov.usds.vaccineschedule.common.helpers.NDJSONToFHIR;
+import org.hl7.fhir.r4.model.Location;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+
+import java.io.InputStream;
+import java.util.List;
+
+import static gov.usds.vaccineschedule.common.Constants.ORIGINAL_ID_SYSTEM;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Created by nickrobison on 3/30/21
+ */
+public class TestLocationService extends BaseApplicationTest {
+
+    @Autowired
+    LocationService service;
+
+    @Test
+    void testLocationUpdate() {
+
+        final IParser parser = ctx.newJsonParser();
+        final NDJSONToFHIR converter = new NDJSONToFHIR(parser);
+
+        // Pull a single location out of the NDJSON file
+        final InputStream is = TestLocationService.class.getClassLoader().getResourceAsStream("example-locations.ndjson");
+        final Location firstLoc = converter.inputStreamToTypedResource(Location.class, is).get(0);
+        // Update the name and save it
+        firstLoc.setName("I'm an updated name");
+        service.addLocation(firstLoc);
+        // Now, find it and pull back out
+        final TokenParam tokenParam = new TokenParam().setSystem(ORIGINAL_ID_SYSTEM).setValue(firstLoc.getId());
+        final Location updatedLocation = service.findLocations(tokenParam, null, null, null, PageRequest.of(0, 10)).get(0);
+        assertEquals(firstLoc.getName(), updatedLocation.getName(), "Should have updated name");
+    }
+
+    @Test
+    void testLoadNoChange() {
+        final long origCount = this.service.countLocations(null, null, null, null);
+        final IParser parser = ctx.newJsonParser();
+        final NDJSONToFHIR converter = new NDJSONToFHIR(parser);
+        final InputStream is = TestLocationService.class.getClassLoader().getResourceAsStream("example-locations.ndjson");
+        final List<Location> locations = converter.inputStreamToTypedResource(Location.class, is);
+        this.service.addLocations(locations);
+        assertEquals(origCount, this.service.countLocations(null, null, null, null), "Count should not change");
+    }
+
+}

--- a/api-application/src/test/java/gov/usds/vaccineschedule/api/services/TestScheduleService.java
+++ b/api-application/src/test/java/gov/usds/vaccineschedule/api/services/TestScheduleService.java
@@ -1,0 +1,55 @@
+package gov.usds.vaccineschedule.api.services;
+
+import ca.uhn.fhir.parser.IParser;
+import ca.uhn.fhir.rest.param.TokenParam;
+import gov.usds.vaccineschedule.api.BaseApplicationTest;
+import gov.usds.vaccineschedule.common.helpers.NDJSONToFHIR;
+import org.hl7.fhir.r4.model.Identifier;
+import org.hl7.fhir.r4.model.Schedule;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
+
+import java.io.InputStream;
+import java.util.List;
+
+import static gov.usds.vaccineschedule.common.Constants.ORIGINAL_ID_SYSTEM;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Created by nickrobison on 4/7/21
+ */
+public class TestScheduleService extends BaseApplicationTest {
+
+    @Autowired
+    private ScheduleService service;
+
+    @Test
+    void testScheduleUpdate() {
+        final IParser parser = ctx.newJsonParser();
+        final NDJSONToFHIR converter = new NDJSONToFHIR(parser);
+
+        // Pull a single location out of the NDJSON file
+        final InputStream is = TestLocationService.class.getClassLoader().getResourceAsStream("example-schedules.ndjson");
+        final Schedule firstSchedule = converter.inputStreamToTypedResource(Schedule.class, is).get(0);
+        firstSchedule.setIdentifier(List.of(new Identifier().setSystem("http://terminology.hl7.org/CodeSystem/service-type2").setValue("57")));
+        this.service.addSchedule(firstSchedule);
+        final TokenParam tokenParam = new TokenParam().setSystem(ORIGINAL_ID_SYSTEM).setValue(firstSchedule.getId());
+        final Schedule updatedSchedule = service.getScheduleWithIdentifier(tokenParam, Pageable.unpaged()).get(0);
+        assertEquals(4, updatedSchedule.getIdentifier().size(), "Should only have a single identifier");
+    }
+
+    @Test
+    void testLoadNoChange() {
+        final IParser parser = ctx.newJsonParser();
+        final NDJSONToFHIR converter = new NDJSONToFHIR(parser);
+
+        final long origCount = this.service.countAllSchedules();
+
+        // Pull a single location out of the NDJSON file
+        final InputStream is = TestLocationService.class.getClassLoader().getResourceAsStream("example-schedules.ndjson");
+        final List<Schedule> schedules = converter.inputStreamToTypedResource(Schedule.class, is);
+        this.service.addSchedules(schedules);
+        assertEquals(origCount, this.service.countAllSchedules(), "Count should not change");
+    }
+}

--- a/api-application/src/test/java/gov/usds/vaccineschedule/api/services/TestSlotService.java
+++ b/api-application/src/test/java/gov/usds/vaccineschedule/api/services/TestSlotService.java
@@ -1,0 +1,56 @@
+package gov.usds.vaccineschedule.api.services;
+
+import ca.uhn.fhir.parser.IParser;
+import ca.uhn.fhir.rest.param.TokenParam;
+import gov.usds.vaccineschedule.api.BaseApplicationTest;
+import gov.usds.vaccineschedule.common.helpers.NDJSONToFHIR;
+import gov.usds.vaccineschedule.common.models.VaccineSlot;
+import org.hl7.fhir.r4.model.IntegerType;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+
+import java.io.InputStream;
+import java.util.List;
+
+import static gov.usds.vaccineschedule.common.Constants.ORIGINAL_ID_SYSTEM;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Created by nickrobison on 4/7/21
+ */
+public class TestSlotService extends BaseApplicationTest {
+
+    @Autowired
+    SlotService service;
+
+    @Test
+    void testSlotUpdate() {
+        final IParser parser = ctx.newJsonParser();
+        final NDJSONToFHIR converter = new NDJSONToFHIR(parser);
+
+        // Pull a single location out of the NDJSON file
+        final InputStream is = TestLocationService.class.getClassLoader().getResourceAsStream("example-slots.ndjson");
+        final VaccineSlot firstSlot = converter.inputStreamToTypedResource(VaccineSlot.class, is).get(0);
+        firstSlot.setCapacity(new IntegerType(5));
+        service.addSlot(firstSlot);
+        final TokenParam tokenParam = new TokenParam().setSystem(ORIGINAL_ID_SYSTEM).setValue(firstSlot.getId());
+        final VaccineSlot updatedSlot = (VaccineSlot) service.findSlotsWithId(tokenParam, PageRequest.of(0, 10)).get(0);
+        assertAll(() -> assertTrue(firstSlot.getCapacity().equalsDeep(updatedSlot.getCapacity()), "Should have updated capacity"),
+                () -> assertTrue(firstSlot.getBookingPhone().equalsDeep(updatedSlot.getBookingPhone()), "Should have original phone number"));
+    }
+
+    @Test
+    void testLoadNoChange() {
+        final long origCount = this.service.countSlots();
+
+        final IParser parser = ctx.newJsonParser();
+        final NDJSONToFHIR converter = new NDJSONToFHIR(parser);
+        final InputStream is = TestLocationService.class.getClassLoader().getResourceAsStream("example-slots.ndjson");
+        final List<VaccineSlot> slots = converter.inputStreamToTypedResource(VaccineSlot.class, is);
+        this.service.addSlots(slots);
+        assertEquals(origCount, this.service.countSlots(), "Count should not change");
+    }
+}

--- a/common/src/main/java/gov/usds/vaccineschedule/common/Constants.java
+++ b/common/src/main/java/gov/usds/vaccineschedule/common/Constants.java
@@ -6,4 +6,5 @@ package gov.usds.vaccineschedule.common;
 public class Constants {
 
     public static final String FHIR_NDJSON = "application/fhir+ndjson";
+    public static String ORIGINAL_ID_SYSTEM = "http://usds.gov/vaccine/source-identifier";
 }


### PR DESCRIPTION
We can now update values on existing entities and ensure that when we refresh upstream sources we don't just create duplicated values.

closes #30 