### PR TITLE
Propagate updated timestamps for FHIR resources

### DIFF
--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/db/models/LocationEntity.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/db/models/LocationEntity.java
@@ -3,7 +3,9 @@ package gov.usds.vaccineschedule.api.db.models;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.hl7.fhir.r4.model.ContactPoint;
 import org.hl7.fhir.r4.model.Identifier;
+import org.hl7.fhir.r4.model.InstantType;
 import org.hl7.fhir.r4.model.Location;
+import org.hl7.fhir.r4.model.Meta;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
@@ -16,6 +18,7 @@ import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -111,6 +114,13 @@ public class LocationEntity extends BaseEntity implements Flammable<Location>, I
     @Override
     public Location toFHIR() {
         final Location location = new Location();
+
+        if (this.getUpdatedAt() != null) {
+            final Meta meta = new Meta();
+            final String fhirDateString = this.getUpdatedAt().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+            meta.setLastUpdatedElement(new InstantType(fhirDateString));
+            location.setMeta(meta);
+        }
 
         location.setId(this.getInternalId().toString());
         location.setName(this.name);

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/db/models/ScheduleEntity.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/db/models/ScheduleEntity.java
@@ -1,6 +1,8 @@
 package gov.usds.vaccineschedule.api.db.models;
 
 import org.hl7.fhir.r4.model.Identifier;
+import org.hl7.fhir.r4.model.InstantType;
+import org.hl7.fhir.r4.model.Meta;
 import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.Schedule;
 
@@ -10,6 +12,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
+import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -56,6 +59,13 @@ public class ScheduleEntity extends BaseEntity implements Flammable<Schedule> {
     @Override
     public Schedule toFHIR() {
         final Schedule schedule = new Schedule();
+
+        if (this.getUpdatedAt() != null) {
+            final Meta meta = new Meta();
+            final String fhirDateString = this.getUpdatedAt().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+            meta.setLastUpdatedElement(new InstantType(fhirDateString));
+            schedule.setMeta(meta);
+        }
 
         schedule.setId(this.getInternalId().toString());
         schedule.addIdentifier(HL7_IDENTIFIER);

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/models/BundleFactory.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/models/BundleFactory.java
@@ -5,9 +5,12 @@ import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.InstantType;
+import org.hl7.fhir.r4.model.Meta;
 import org.hl7.fhir.r4.model.Resource;
 
+import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -38,8 +41,18 @@ public class BundleFactory {
         builder.addLinks(bundle);
 
         // Search time
-        // Should have last updated as well
+
         bundle.setTimestampElement(searchTime);
+        // Also set the last updated time to the newest element in the bundle
+        // This is what BFD does, seems like a good idea.
+        final Meta meta = new Meta();
+        resources
+                .stream()
+                .map(r -> r.getMeta().getLastUpdated())
+                .filter(Objects::nonNull)
+                .max(Date::compareTo)
+                .map(meta::setLastUpdated);
+        bundle.setMeta(meta);
         return bundle;
     }
 

--- a/api-application/src/test/java/gov/usds/vaccineschedule/api/providers/LocationProviderTest.java
+++ b/api-application/src/test/java/gov/usds/vaccineschedule/api/providers/LocationProviderTest.java
@@ -9,6 +9,8 @@ import org.hl7.fhir.r4.model.Location;
 import org.hl7.fhir.r4.model.Resource;
 import org.junit.jupiter.api.Test;
 
+import java.sql.Date;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -25,6 +27,7 @@ public class LocationProviderTest extends BaseApplicationTest {
 
     @Test
     public void testLocationEverything() {
+        final java.util.Date searchTime = Date.from(Instant.now());
         final IGenericClient client = provideFhirClient();
         final Bundle results = client.search()
                 .forResource(Location.class)
@@ -33,7 +36,7 @@ public class LocationProviderTest extends BaseApplicationTest {
                 .encodedJson()
                 .execute();
 
-        final List<Location> locations = unwrapBundle(client, results);
+        final List<Location> locations = unwrapBundle(client, results, searchTime);
         final long uniqueIDs = locations.stream().map(Resource::getId).distinct().count();
 
         assertAll(() -> assertEquals(10, locations.size(), "Should have all the results"),
@@ -42,6 +45,7 @@ public class LocationProviderTest extends BaseApplicationTest {
 
     @Test
     public void testLocationSearch() {
+        final java.util.Date searchTime = Date.from(Instant.now());
         final IGenericClient client = provideFhirClient();
         Map<String, List<IQueryParameterType>> params = new HashMap<>();
         params.put("near", List.of(new TokenParam().setValue("42.4887|-71.2837|50")));
@@ -53,7 +57,7 @@ public class LocationProviderTest extends BaseApplicationTest {
                 .encodedJson()
                 .execute();
 
-        List<Location> resources = unwrapBundle(client, results);
+        List<Location> resources = unwrapBundle(client, results, searchTime);
 
         assertEquals(7, resources.size(), "Should equal");
     }

--- a/api-application/src/test/java/gov/usds/vaccineschedule/api/providers/SlotProviderTest.java
+++ b/api-application/src/test/java/gov/usds/vaccineschedule/api/providers/SlotProviderTest.java
@@ -11,6 +11,7 @@ import org.hl7.fhir.r4.model.Slot;
 import org.junit.jupiter.api.Test;
 
 import java.sql.Date;
+import java.time.Instant;
 import java.util.List;
 
 import static gov.usds.vaccineschedule.api.utils.FhirHandlers.unwrapBundle;
@@ -26,6 +27,7 @@ public class SlotProviderTest extends BaseApplicationTest {
 
     @Test
     void testAllSlotsWithPagination() {
+        final java.util.Date searchTime = Date.from(Instant.now());
         final IGenericClient client = provideFhirClient();
 
         Bundle slots = client
@@ -37,7 +39,7 @@ public class SlotProviderTest extends BaseApplicationTest {
                 .encodedJson()
                 .execute();
 
-        final List<VaccineSlot> vSlots = unwrapBundle(client, slots);
+        final List<VaccineSlot> vSlots = unwrapBundle(client, slots, searchTime);
 
         final long uniqueIds = vSlots.stream().map(Resource::getId).distinct().count();
         assertAll(() -> assertEquals(70, vSlots.size(), "Should have all the slots"),

--- a/api-application/src/test/java/gov/usds/vaccineschedule/api/services/TestLocationService.java
+++ b/api-application/src/test/java/gov/usds/vaccineschedule/api/services/TestLocationService.java
@@ -8,12 +8,15 @@ import org.hl7.fhir.r4.model.Location;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import java.io.InputStream;
 import java.util.List;
 
 import static gov.usds.vaccineschedule.common.Constants.ORIGINAL_ID_SYSTEM;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Created by nickrobison on 3/30/21
@@ -32,13 +35,18 @@ public class TestLocationService extends BaseApplicationTest {
         // Pull a single location out of the NDJSON file
         final InputStream is = TestLocationService.class.getClassLoader().getResourceAsStream("example-locations.ndjson");
         final Location firstLoc = converter.inputStreamToTypedResource(Location.class, is).get(0);
+
+        // Pull out the location to cache it
+        final TokenParam tokenParam = new TokenParam().setSystem(ORIGINAL_ID_SYSTEM).setValue(firstLoc.getId());
+        final Location origLocation = this.service.findLocations(tokenParam, null, null, null, Pageable.unpaged()).get(0);
         // Update the name and save it
         firstLoc.setName("I'm an updated name");
         service.addLocation(firstLoc);
         // Now, find it and pull back out
-        final TokenParam tokenParam = new TokenParam().setSystem(ORIGINAL_ID_SYSTEM).setValue(firstLoc.getId());
+
         final Location updatedLocation = service.findLocations(tokenParam, null, null, null, PageRequest.of(0, 10)).get(0);
-        assertEquals(firstLoc.getName(), updatedLocation.getName(), "Should have updated name");
+        assertAll(() -> assertEquals(firstLoc.getName(), updatedLocation.getName(), "Should have updated name"),
+                () -> assertFalse(origLocation.getMeta().getLastUpdatedElement().equalsDeep(updatedLocation.getMeta().getLastUpdatedElement()), "Update timestamp should be different"));
     }
 
     @Test

--- a/api-application/src/test/java/gov/usds/vaccineschedule/api/utils/FhirHandlers.java
+++ b/api-application/src/test/java/gov/usds/vaccineschedule/api/utils/FhirHandlers.java
@@ -4,8 +4,10 @@ import ca.uhn.fhir.rest.client.api.IGenericClient;
 import gov.usds.vaccineschedule.common.models.VaccineSlot;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Resource;
+import org.junit.jupiter.api.Assertions;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 /**
@@ -14,16 +16,27 @@ import java.util.List;
 public class FhirHandlers {
 
     @SuppressWarnings("unchecked")
-    public static <T extends Resource> List<T> unwrapBundle(IGenericClient client, Bundle bundle) {
+    public static <T extends Resource> List<T> unwrapBundle(IGenericClient client, Bundle bundle, Date searchTime) {
+        int idx = 0;
+        assertBundleUpdatedBefore(bundle, searchTime);
         List<T> resources = new ArrayList<>();
         // Loop through all the pages
         bundle.getEntry().forEach(e -> resources.add((T) e.getResource()));
 
         while (bundle.getLink(Bundle.LINK_NEXT) != null) {
+            idx++;
             bundle = client.loadPage().next(bundle).preferResponseType(VaccineSlot.class).execute();
+            assertBundleUpdatedBefore(bundle, searchTime);
             bundle.getEntry().forEach(e -> resources.add((T) e.getResource()));
         }
 
         return resources;
+    }
+
+    private static void assertBundleUpdatedBefore(Bundle bundle, Date searchTime) {
+        if (!bundle.getEntry().isEmpty()) {
+            Assertions.assertTrue(bundle.getMeta().getLastUpdatedElement().before(searchTime), "Updated value should be before search time");
+        }
+
     }
 }

--- a/common/src/main/java/gov/usds/vaccineschedule/common/Constants.java
+++ b/common/src/main/java/gov/usds/vaccineschedule/common/Constants.java
@@ -1,10 +1,29 @@
 package gov.usds.vaccineschedule.common;
 
+import org.hl7.fhir.r4.model.DateTimeType;
+import org.hl7.fhir.r4.model.InstantType;
+
+import java.time.format.DateTimeFormatter;
+
 /**
  * Created by nickrobison on 4/6/21
  */
 public class Constants {
 
     public static final String FHIR_NDJSON = "application/fhir+ndjson";
+    /**
+     * {@link DateTimeFormatter} which outputs in a format parsable by {@link DateTimeType}.
+     * See: https://www.hl7.org/fhir/datatypes.html#dateTime
+     */
+    public static final DateTimeFormatter FHIR_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssxxx");
+
+
+    /**
+     * {@link DateTimeFormatter} which outputs in a format parsable by {@link InstantType}.
+     * See: https://www.hl7.org/fhir/datatypes.html#instant
+     */
+//    public static final DateTimeFormatter INSTANT_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSxxx");
+    public static final DateTimeFormatter INSTANT_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSVV");
+
     public static String ORIGINAL_ID_SYSTEM = "http://usds.gov/vaccine/source-identifier";
 }


### PR DESCRIPTION
Resources now propagate their last updated time in their meta section.

We're also following the pattern adopted by CMS BFD and using the newest updated value from the resources when building our return bundle.

closes #22 