### PR TITLE
A potpuri of fixes

### DIFF
--- a/api-application/build.gradle
+++ b/api-application/build.gradle
@@ -55,6 +55,9 @@ dependencies {
     implementation "ca.uhn.hapi.fhir:hapi-fhir-validation:${hapiVersion}"
     implementation "ca.uhn.hapi.fhir:hapi-fhir-validation-resources-r4:${hapiVersion}"
 
+    // Deployment
+    implementation 'com.rollbar:rollbar-spring-boot-webmvc:1.7.6'
+
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/ScheduleApiApplication.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/ScheduleApiApplication.java
@@ -2,6 +2,7 @@ package gov.usds.vaccineschedule.api;
 
 import gov.usds.vaccineschedule.api.config.GeocoderConfig;
 import gov.usds.vaccineschedule.api.config.ScheduleSourceConfig;
+import gov.usds.vaccineschedule.api.properties.RollbarConfigurationProperties;
 import gov.usds.vaccineschedule.api.services.ExampleDataService;
 import gov.usds.vaccineschedule.api.services.ScheduledTaskService;
 import gov.usds.vaccineschedule.api.services.geocoder.DBGeocoderService;
@@ -19,7 +20,8 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @SpringBootApplication
 @EnableConfigurationProperties({
         ScheduleSourceConfig.class,
-        GeocoderConfig.class
+        GeocoderConfig.class,
+        RollbarConfigurationProperties.class
 })
 @EnableScheduling
 public class ScheduleApiApplication {

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/config/RollbarConfig.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/config/RollbarConfig.java
@@ -1,0 +1,35 @@
+package gov.usds.vaccineschedule.api.config;
+
+import com.rollbar.notifier.Rollbar;
+import com.rollbar.notifier.config.Config;
+import com.rollbar.spring.webmvc.RollbarSpringConfigBuilder;
+import gov.usds.vaccineschedule.api.properties.RollbarConfigurationProperties;
+import gov.usds.vaccineschedule.api.services.RollbarServerProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.stereotype.Component;
+
+/**
+ * Created by nickrobison on 4/7/21
+ */
+@Component
+@ConditionalOnProperty(value = "rollbar.enabled", havingValue = "true")
+@ComponentScan("com.rollbar.spring")
+public class RollbarConfig {
+
+    private static final Logger logger = LoggerFactory.getLogger(RollbarConfig.class);
+
+    @Bean
+    public Rollbar rollbar(RollbarConfigurationProperties properties, RollbarServerProvider provider) {
+        logger.debug("Rollbar properties: {}", properties);
+
+        final Config builder = RollbarSpringConfigBuilder
+                .withAccessToken(properties.getAccessToken())
+                .environment(properties.getEnvironment())
+                .server(provider).build();
+        return new Rollbar(builder);
+    }
+}

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/config/ScheduleSourceConfig.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/config/ScheduleSourceConfig.java
@@ -28,12 +28,15 @@ public class ScheduleSourceConfig {
      */
     private final TimeZone scheduleTimezone;
 
+    private final Integer dbThreadPoolSize;
+
     @ConstructorBinding
-    public ScheduleSourceConfig(boolean scheduleEnabled, List<String> sources, List<String> refreshSchedule, TimeZone scheduleTimezone) {
+    public ScheduleSourceConfig(boolean scheduleEnabled, List<String> sources, List<String> refreshSchedule, TimeZone scheduleTimezone, Integer dbThreadPoolSize) {
         this.scheduleEnabled = scheduleEnabled;
         this.sources = sources;
         this.refreshSchedule = refreshSchedule;
         this.scheduleTimezone = scheduleTimezone;
+        this.dbThreadPoolSize = dbThreadPoolSize;
     }
 
     public boolean getScheduleEnabled() {
@@ -50,5 +53,9 @@ public class ScheduleSourceConfig {
 
     public TimeZone getScheduleTimezone() {
         return scheduleTimezone;
+    }
+
+    public Integer getDbThreadPoolSize() {
+        return dbThreadPoolSize;
     }
 }

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/properties/RollbarConfigurationProperties.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/properties/RollbarConfigurationProperties.java
@@ -1,0 +1,46 @@
+package gov.usds.vaccineschedule.api.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+/**
+ * Created by nickrobison on 4/7/21
+ */
+@ConfigurationProperties(prefix = "rollbar")
+public class RollbarConfigurationProperties {
+
+    private boolean enabled;
+    private String accessToken;
+    private String branch;
+    private String codeVersion;
+    private String environment;
+
+    @ConstructorBinding
+    public RollbarConfigurationProperties(boolean enabled, String accessToken, String branch, String codeVersion, String environment) {
+        this.enabled = enabled;
+        this.accessToken = accessToken;
+        this.branch = branch;
+        this.codeVersion = codeVersion;
+        this.environment = environment;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public String getBranch() {
+        return branch;
+    }
+
+    public String getCodeVersion() {
+        return codeVersion;
+    }
+
+    public String getEnvironment() {
+        return environment;
+    }
+}

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/services/RollbarServerProvider.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/services/RollbarServerProvider.java
@@ -1,0 +1,34 @@
+package gov.usds.vaccineschedule.api.services;
+
+import com.rollbar.api.payload.data.Server;
+import com.rollbar.notifier.provider.Provider;
+import gov.usds.vaccineschedule.api.properties.RollbarConfigurationProperties;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+/**
+ * Created by nickrobison on 4/7/21
+ */
+@Component
+@Lazy
+public class RollbarServerProvider implements Provider<Server> {
+
+    private final Environment env;
+    private final RollbarConfigurationProperties config;
+
+    public RollbarServerProvider(Environment env, RollbarConfigurationProperties config) {
+        this.env = env;
+        this.config = config;
+    }
+
+    @Override
+    public Server provide() {
+        return new Server.Builder()
+                .codeVersion(config.getCodeVersion())
+                .branch(config.getBranch())
+                .host(env.getProperty("spring.application.name"))
+                .root("gov.usds.vaccineschedule.api")
+                .build();
+    }
+}

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/services/SourceFetchService.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/services/SourceFetchService.java
@@ -106,14 +106,13 @@ public class SourceFetchService {
                 .bodyToMono(PublishResponse.class);
 
         this.disposable = buildResourceFetcher(client, publishResponseMono)
-                .doOnComplete(() -> logger.info("Finished refreshing data for {}", source))
                 .publishOn(this.dbScheduler)
                 .subscribe(resource -> {
                     logger.debug("Received resource: {}", resource);
                     this.processResource(resource);
                 }, (error) -> {
                     throw new RuntimeException(error);
-                });
+                }, () -> logger.info("Finished refreshing data for {}", source));
     }
 
     private Flux<IBaseResource> handleResource(WebClient client, String resourceType, PublishResponse response) {

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/services/SourceFetchService.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/services/SourceFetchService.java
@@ -1,10 +1,7 @@
 package gov.usds.vaccineschedule.api.services;
 
 import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.validation.FhirValidator;
-import ca.uhn.fhir.validation.ValidationFailureException;
-import ca.uhn.fhir.validation.ValidationOptions;
-import ca.uhn.fhir.validation.ValidationResult;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import gov.usds.vaccineschedule.api.config.ScheduleSourceConfig;
 import gov.usds.vaccineschedule.common.helpers.NDJSONToFHIR;
@@ -18,6 +15,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.http.MediaType;
+import org.springframework.http.codec.json.Jackson2CodecSupport;
+import org.springframework.http.codec.json.Jackson2JsonDecoder;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientException;
@@ -27,7 +27,6 @@ import reactor.core.publisher.Mono;
 import reactor.core.publisher.Sinks;
 
 import java.util.List;
-import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -40,26 +39,21 @@ import static gov.usds.vaccineschedule.common.Constants.FHIR_NDJSON;
 public class SourceFetchService {
     private static final Logger logger = LoggerFactory.getLogger(SourceFetchService.class);
 
-    private static final Map<String, String> profileMap = buildProfileMap();
     private static final List<String> resourceOrder = ImmutableList.of("Location", "Schedule", "Slot");
 
-    private final FhirContext ctx;
     private final ScheduleSourceConfig config;
     private final NDJSONToFHIR converter;
     private final Sinks.Many<String> processor;
     private final LocationService locationService;
     private final ScheduleService sService;
     private final SlotService slService;
-    private final FhirValidator validator;
 
     private Disposable disposable;
 
-    public SourceFetchService(FhirContext context, ScheduleSourceConfig config, LocationService locationService, ScheduleService sService, SlotService slService, FhirValidator validator) {
-        this.ctx = context;
+    public SourceFetchService(FhirContext context, ScheduleSourceConfig config, LocationService locationService, ScheduleService sService, SlotService slService) {
         this.config = config;
         this.converter = new NDJSONToFHIR(context.newJsonParser());
         this.slService = slService;
-        this.validator = validator;
         this.processor = Sinks.many().unicast().onBackpressureBuffer();
         this.locationService = locationService;
         this.sService = sService;
@@ -95,10 +89,11 @@ public class SourceFetchService {
     }
 
     private void handleRefresh(String source) {
+        final WebClient client = buildClient(source);
         // Each upstream publisher is independent from the others, so we can process them in parallel
-        final WebClient client = WebClient.create(source);
         final Mono<PublishResponse> publishResponseMono = client.get()
                 .uri("/$bulk-publish")
+                .accept(MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN)
                 .retrieve()
                 .bodyToMono(PublishResponse.class);
 
@@ -117,20 +112,7 @@ public class SourceFetchService {
                 .filter(o -> o.getType().equals(resourceType))
                 .doOnNext(o -> logger.debug("Fetching resource of type: {} from: {}", o.getType(), o.getUrl()))
                 .flatMap(output -> client.get().uri(output.getUrl()).accept(MediaType.parseMediaType(FHIR_NDJSON)).retrieve().bodyToMono(DataBuffer.class))
-                .flatMap(body -> Flux.fromIterable(converter.inputStreamToResource(body.asInputStream(true))))
-                .doOnNext(this::validateResource);
-    }
-
-    private void validateResource(IBaseResource resource) {
-        final String resourceName = resource.getClass().getSimpleName();
-        final String profile = profileMap.get(resourceName);
-        logger.debug("Validating {} resource against profile: {}", resourceName, profile);
-        final ValidationOptions options = new ValidationOptions();
-        options.addProfile(profile);
-        final ValidationResult result = this.validator.validateWithResult(resource, options);
-        if (!result.isSuccessful()) {
-            throw new ValidationFailureException(this.ctx, result.toOperationOutcome());
-        }
+                .flatMap(body -> Flux.fromIterable(converter.inputStreamToResource(body.asInputStream(true))));
     }
 
 
@@ -146,9 +128,25 @@ public class SourceFetchService {
                         });
     }
 
-    private static Map<String, String> buildProfileMap() {
-        return Map.of("Location", "http://fhir-registry.smarthealthit.org/StructureDefinition/vaccine-location",
-                "Schedule", "http://fhir-registry.smarthealthit.org/StructureDefinition/vaccine-schedule",
-                "VaccineSlot", "http://fhir-registry.smarthealthit.org/StructureDefinition/vaccine-slot");
+    private WebClient buildClient(String baseURL) {
+        return WebClient.builder()
+                .baseUrl(baseURL)
+                // Configure Jackson to handle text/plain content types as well, such as what we get from Github
+                .codecs(configurer -> {
+                    // This API returns JSON with content type text/plain, so need to register a custom
+                    // decoder to deserialize this response via Jackson
+
+                    // Get existing decoder's ObjectMapper if available, or create new one
+                    ObjectMapper objectMapper = configurer.getReaders().stream()
+                            .filter(reader -> reader instanceof Jackson2JsonDecoder)
+                            .map(reader -> (Jackson2JsonDecoder) reader)
+                            .map(Jackson2CodecSupport::getObjectMapper)
+                            .findFirst()
+                            .orElseGet(() -> Jackson2ObjectMapperBuilder.json().build());
+
+                    Jackson2JsonDecoder decoder = new Jackson2JsonDecoder(objectMapper, MediaType.TEXT_PLAIN);
+                    configurer.customCodecs().registerWithDefaultConfig(decoder);
+                })
+                .build();
     }
 }

--- a/api-application/src/main/resources/application-heroku.yml
+++ b/api-application/src/main/resources/application-heroku.yml
@@ -1,4 +1,11 @@
-vs.geocoder.mapbox-token: ${MAPBOX_TOKEN}
+vs:
+  geocoder.mapbox-token: ${MAPBOX_TOKEN}
+  schedule-source:
+    schedule-enabled: false
+    upload-schedule: "0 0 11 * * *" # Daily at 11:00 AM Eastern Time
+    upload-timezone: America/New_York
+    sources:
+      - "https://raw.githubusercontent.com/smart-on-fhir/smart-scheduling-links/master/examples/"
 spring:
   datasource:
     hikari:

--- a/api-application/src/main/resources/application-heroku.yml
+++ b/api-application/src/main/resources/application-heroku.yml
@@ -6,6 +6,7 @@ vs:
     upload-timezone: America/New_York
     sources:
       - "https://raw.githubusercontent.com/smart-on-fhir/smart-scheduling-links/master/examples/"
+    db-thread-pool-size: 2
 spring:
   datasource:
     hikari:

--- a/api-application/src/main/resources/application-heroku.yml
+++ b/api-application/src/main/resources/application-heroku.yml
@@ -5,3 +5,9 @@ spring:
       maximum-pool-size: 2
   rabbitmq:
     addresses: ${CLOUDAMQP_URL}
+rollbar:
+  access-token: ${ROLLBAR_ACCESS_TOKEN}
+  branch: main
+  enabled: false
+  environment: heroku
+  code-version: 0.0.1

--- a/api-application/src/main/resources/application.yml
+++ b/api-application/src/main/resources/application.yml
@@ -26,6 +26,7 @@ vs:
     upload-timezone: America/New_York
     sources:
       - "http://localhost:9090/"
+    db-thread-pool-size: 5
 management.endpoints.web:
   exposure:
     include: health, info, refresh

--- a/api-application/src/test/java/gov/usds/vaccineschedule/api/services/FetchServiceTest.java
+++ b/api-application/src/test/java/gov/usds/vaccineschedule/api/services/FetchServiceTest.java
@@ -72,7 +72,7 @@ public class FetchServiceTest extends BaseApplicationTest {
         lService = Mockito.mock(LocationService.class);
         scheduleService = Mockito.mock(ScheduleService.class);
         slotService = Mockito.mock(SlotService.class);
-        final ScheduleSourceConfig config = new ScheduleSourceConfig(false, List.of(baseUrl), Collections.emptyList(), TimeZone.getDefault());
+        final ScheduleSourceConfig config = new ScheduleSourceConfig(false, List.of(baseUrl), Collections.emptyList(), TimeZone.getDefault(), 2);
         service = new SourceFetchService(ctx, config, lService, scheduleService, slotService);
     }
 

--- a/api-application/src/test/java/gov/usds/vaccineschedule/api/services/FetchServiceTest.java
+++ b/api-application/src/test/java/gov/usds/vaccineschedule/api/services/FetchServiceTest.java
@@ -1,8 +1,6 @@
 package gov.usds.vaccineschedule.api.services;
 
 import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.validation.FhirValidator;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.usds.vaccineschedule.api.BaseApplicationTest;
 import gov.usds.vaccineschedule.api.config.ScheduleSourceConfig;
 import gov.usds.vaccineschedule.common.models.PublishResponse;
@@ -50,10 +48,6 @@ public class FetchServiceTest extends BaseApplicationTest {
 
     @Autowired
     private FhirContext ctx;
-    @Autowired
-    private ObjectMapper mapper;
-    @Autowired
-    private FhirValidator validator;
     private LocationService lService;
     private ScheduleService scheduleService;
     private SlotService slotService;
@@ -79,7 +73,7 @@ public class FetchServiceTest extends BaseApplicationTest {
         scheduleService = Mockito.mock(ScheduleService.class);
         slotService = Mockito.mock(SlotService.class);
         final ScheduleSourceConfig config = new ScheduleSourceConfig(false, List.of(baseUrl), Collections.emptyList(), TimeZone.getDefault());
-        service = new SourceFetchService(ctx, config, lService, scheduleService, slotService, validator);
+        service = new SourceFetchService(ctx, config, lService, scheduleService, slotService);
     }
 
     @AfterEach


### PR DESCRIPTION
Initially, this was just supposed to add Rollbar and update the Heroku service to point towards the the FHIR specification repo.

Ho, boy..... It's just bugs all the way down.

Let's see if I can get everything straight:

- Updated the WebClient configuration to treat `text/plain` mediatypes as de jure JSON and let Jackson complain if it's not right.
- Discovered the source fetch process was deadlocking when using the Mapbox geocoder. Splitting the DB operations into their own thread pool (via `publishOn`) seems to have resolved that issue and is a good idea anyways.
- Moved the resource validation into the various services, so now every write path is covered.
- A number of other small tweaks and cleanups. 


closes #44 (Using a separate thread pool for WebClient requires a scary number of beans and configuration overrides)
closes #36 

