### PR TITLE
Implement H3 distance engine

### DIFF
--- a/api-application/build.gradle
+++ b/api-application/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     // Spatial data
     implementation 'de.grundid.opendatalab:geojson-jackson:1.14'
     implementation 'org.hibernate:hibernate-spatial'
+    implementation 'com.uber:h3:3.7.0'
 
     // Unit conversion
     implementation 'tech.units:indriya:2.1.2'

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/ScheduleApiApplication.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/ScheduleApiApplication.java
@@ -1,8 +1,9 @@
 package gov.usds.vaccineschedule.api;
 
-import gov.usds.vaccineschedule.api.config.GeocoderConfig;
-import gov.usds.vaccineschedule.api.config.ScheduleSourceConfig;
-import gov.usds.vaccineschedule.api.properties.RollbarConfigurationProperties;
+import gov.usds.vaccineschedule.api.properties.GeocoderConfigProperties;
+import gov.usds.vaccineschedule.api.properties.RollbarConfigProperties;
+import gov.usds.vaccineschedule.api.properties.ScheduleSourceConfigProperties;
+import gov.usds.vaccineschedule.api.properties.VaccineScheduleProperties;
 import gov.usds.vaccineschedule.api.services.ExampleDataService;
 import gov.usds.vaccineschedule.api.services.ScheduledTaskService;
 import gov.usds.vaccineschedule.api.services.geocoder.DBGeocoderService;
@@ -20,9 +21,8 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableConfigurationProperties({
-        ScheduleSourceConfig.class,
-        GeocoderConfig.class,
-        RollbarConfigurationProperties.class
+        VaccineScheduleProperties.class,
+        RollbarConfigProperties.class
 })
 @EnableCaching
 @EnableScheduling
@@ -37,13 +37,13 @@ public class ScheduleApiApplication {
      * Note: If running in a cluster, only a single node should be responsible for managing the chron jobs, otherwise, we'll get duplicate executions
      * The backend queue takes care of parallelizing the work amongst all nodes, but the actual job submission should be sequential
      *
-     * @param config    - {@link ScheduleSourceConfig} for configuring
+     * @param config    - {@link ScheduleSourceConfigProperties} for configuring
      * @param scheduler - {@link ScheduledTaskService} for scheduling
      * @return - {@link CommandLineRunner} for running
      */
     @Bean
     @ConditionalOnProperty("vs.schedule-source.schedule-enabled")
-    public CommandLineRunner scheduleSourceFetch(ScheduleSourceConfig config, ScheduledTaskService scheduler) {
+    public CommandLineRunner scheduleSourceFetch(ScheduleSourceConfigProperties config, ScheduledTaskService scheduler) {
         return args -> scheduler.scheduleFetch(config);
     }
 
@@ -61,7 +61,7 @@ public class ScheduleApiApplication {
 
     @Bean
     @ConditionalOnProperty("vs.geocoder.mapbox-token")
-    public GeocoderService provideMapboxCoder(GeocoderConfig config) {
+    public GeocoderService provideMapboxCoder(GeocoderConfigProperties config) {
         return new MapBoxGeocoderService(config);
     }
 }

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/config/RollbarConfig.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/config/RollbarConfig.java
@@ -3,7 +3,7 @@ package gov.usds.vaccineschedule.api.config;
 import com.rollbar.notifier.Rollbar;
 import com.rollbar.notifier.config.Config;
 import com.rollbar.spring.webmvc.RollbarSpringConfigBuilder;
-import gov.usds.vaccineschedule.api.properties.RollbarConfigurationProperties;
+import gov.usds.vaccineschedule.api.properties.RollbarConfigProperties;
 import gov.usds.vaccineschedule.api.services.RollbarServerProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,7 +23,7 @@ public class RollbarConfig {
     private static final Logger logger = LoggerFactory.getLogger(RollbarConfig.class);
 
     @Bean
-    public Rollbar rollbar(RollbarConfigurationProperties properties, RollbarServerProvider provider) {
+    public Rollbar rollbar(RollbarConfigProperties properties, RollbarServerProvider provider) {
         logger.debug("Rollbar properties: {}", properties);
 
         final Config builder = RollbarSpringConfigBuilder

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/db/models/LocationEntity.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/db/models/LocationEntity.java
@@ -46,6 +46,9 @@ public class LocationEntity extends BaseEntity implements Flammable<Location>, I
 
     private Point coordinates;
 
+    @Column(name = "h3_index")
+    private long h3Index;
+
     public LocationEntity() {
         // Hibernate required
     }
@@ -90,6 +93,14 @@ public class LocationEntity extends BaseEntity implements Flammable<Location>, I
 
     public void setCoordinates(Point coordinates) {
         this.coordinates = coordinates;
+    }
+
+    public long getH3Index() {
+        return h3Index;
+    }
+
+    public void setH3Index(long h3Index) {
+        this.h3Index = h3Index;
     }
 
     public void merge(LocationEntity other) {

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/models/NearestQuery.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/models/NearestQuery.java
@@ -24,7 +24,7 @@ public class NearestQuery implements Serializable {
 
 
     private static final long serialVersionUID = 42L;
-    private static final Unit<Length> KM = MetricPrefix.KILO(METRE);
+    public static final Unit<Length> KM = MetricPrefix.KILO(METRE);
     private static final String NUMBER_EXN_FORMAT = "Cannot parse: `%s` as coordinate.";
 
     private final Quantity<Length> distance;
@@ -42,6 +42,10 @@ public class NearestQuery implements Serializable {
 
     public Quantity<Length> getDistance() {
         return distance;
+    }
+
+    public double getDistanceInMeters() {
+        return this.distance.to(METRE).getValue().doubleValue();
     }
 
     public static NearestQuery fromToken(String param) {

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/properties/GeocoderConfigProperties.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/properties/GeocoderConfigProperties.java
@@ -1,18 +1,16 @@
-package gov.usds.vaccineschedule.api.config;
+package gov.usds.vaccineschedule.api.properties;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.ConstructorBinding;
 
 /**
  * Created by nickrobison on 3/30/21
  */
-@ConfigurationProperties(prefix = "vs.geocoder")
-public class GeocoderConfig {
+public class GeocoderConfigProperties {
 
     private final String mapboxToken;
 
     @ConstructorBinding
-    public GeocoderConfig(String mapboxToken) {
+    public GeocoderConfigProperties(String mapboxToken) {
         this.mapboxToken = mapboxToken;
     }
 

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/properties/GeocoderDBConfigProperties.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/properties/GeocoderDBConfigProperties.java
@@ -1,4 +1,4 @@
-package gov.usds.vaccineschedule.api.config;
+package gov.usds.vaccineschedule.api.properties;
 
 import com.zaxxer.hikari.HikariDataSource;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -32,12 +32,12 @@ import java.util.HashMap;
         entityManagerFactoryRef = "tigerEntityManagerFactory",
         transactionManagerRef = "tigerTransactionManager"
 )
-public class GeocoderPersistenceConfiguration {
+public class GeocoderDBConfigProperties {
 
     private final Environment env;
 
 
-    public GeocoderPersistenceConfiguration(Environment environment) {
+    public GeocoderDBConfigProperties(Environment environment) {
         this.env = environment;
     }
 

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/properties/RollbarConfigProperties.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/properties/RollbarConfigProperties.java
@@ -7,7 +7,7 @@ import org.springframework.boot.context.properties.ConstructorBinding;
  * Created by nickrobison on 4/7/21
  */
 @ConfigurationProperties(prefix = "rollbar")
-public class RollbarConfigurationProperties {
+public class RollbarConfigProperties {
 
     private boolean enabled;
     private String accessToken;
@@ -16,7 +16,7 @@ public class RollbarConfigurationProperties {
     private String environment;
 
     @ConstructorBinding
-    public RollbarConfigurationProperties(boolean enabled, String accessToken, String branch, String codeVersion, String environment) {
+    public RollbarConfigProperties(boolean enabled, String accessToken, String branch, String codeVersion, String environment) {
         this.enabled = enabled;
         this.accessToken = accessToken;
         this.branch = branch;

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/properties/ScheduleSourceConfigProperties.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/properties/ScheduleSourceConfigProperties.java
@@ -1,6 +1,5 @@
-package gov.usds.vaccineschedule.api.config;
+package gov.usds.vaccineschedule.api.properties;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.ConstructorBinding;
 
 import java.util.List;
@@ -9,8 +8,7 @@ import java.util.TimeZone;
 /**
  * Created by nickrobison on 3/25/21
  */
-@ConfigurationProperties(prefix = "vs.schedule-source")
-public class ScheduleSourceConfig {
+public class ScheduleSourceConfigProperties {
 
     private final boolean scheduleEnabled;
 
@@ -31,7 +29,7 @@ public class ScheduleSourceConfig {
     private final Integer dbThreadPoolSize;
 
     @ConstructorBinding
-    public ScheduleSourceConfig(boolean scheduleEnabled, List<String> sources, List<String> refreshSchedule, TimeZone scheduleTimezone, Integer dbThreadPoolSize) {
+    public ScheduleSourceConfigProperties(boolean scheduleEnabled, List<String> sources, List<String> refreshSchedule, TimeZone scheduleTimezone, Integer dbThreadPoolSize) {
         this.scheduleEnabled = scheduleEnabled;
         this.sources = sources;
         this.refreshSchedule = refreshSchedule;

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/properties/VaccineScheduleProperties.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/properties/VaccineScheduleProperties.java
@@ -1,0 +1,51 @@
+package gov.usds.vaccineschedule.api.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Created by nickrobison on 4/8/21
+ */
+@ConfigurationProperties(prefix = "vs")
+public class VaccineScheduleProperties {
+
+    /**
+     * Default resolution to use when generating H3 ID
+     */
+    private final Integer h3Resolution;
+    /**
+     * Whether or not to use H3 for doing the distance searches
+     * This *should* be faster, but less accurate
+     */
+    private final boolean useH3Search;
+
+    private final ScheduleSourceConfigProperties scheduleSource;
+    private final GeocoderConfigProperties geocoder;
+
+    @ConstructorBinding
+    public VaccineScheduleProperties(Integer h3Resolution, boolean useH3Search, ScheduleSourceConfigProperties scheduleSource, GeocoderConfigProperties geocoder) {
+        this.h3Resolution = h3Resolution;
+        this.useH3Search = useH3Search;
+        this.scheduleSource = scheduleSource;
+        this.geocoder = geocoder;
+    }
+
+    public Integer getH3Resolution() {
+        return h3Resolution;
+    }
+
+    public boolean isUseH3Search() {
+        return useH3Search;
+    }
+
+    @Bean
+    public ScheduleSourceConfigProperties getScheduleSource() {
+        return scheduleSource;
+    }
+
+    @Bean
+    public GeocoderConfigProperties getGeocoder() {
+        return geocoder;
+    }
+}

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/repositories/LocationRepository.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/repositories/LocationRepository.java
@@ -25,6 +25,7 @@ public interface LocationRepository extends JpaRepository<LocationEntity, UUID>,
     )
     List<LocationEntity> locationsWithinDistance(Point location, double distance, Pageable page);
 
+
     @Query(
             "select count(*) from LocationEntity l where distance(l.coordinates, :location) < :distance"
     )
@@ -51,5 +52,9 @@ public interface LocationRepository extends JpaRepository<LocationEntity, UUID>,
 
     static Specification<LocationEntity> inPostalCode(String postalCode) {
         return (root, cq, cb) -> cb.equal(root.get(LocationEntity_.address).get(AddressElement_.postalCode), postalCode);
+    }
+
+    static Specification<LocationEntity> inH3Indexes(List<Long> h3Indexes) {
+        return (root, cq, cb) -> root.get(LocationEntity_.h3Index).in(h3Indexes);
     }
 }

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/services/H3Service.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/services/H3Service.java
@@ -1,0 +1,82 @@
+package gov.usds.vaccineschedule.api.services;
+
+import com.uber.h3core.H3Core;
+import com.uber.h3core.LengthUnit;
+import com.uber.h3core.exceptions.PentagonEncounteredException;
+import gov.usds.vaccineschedule.api.models.NearestQuery;
+import gov.usds.vaccineschedule.api.properties.VaccineScheduleProperties;
+import org.locationtech.jts.geom.Point;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Created by nickrobison on 4/8/21
+ */
+@Service
+public class H3Service {
+    private static final Logger logger = LoggerFactory.getLogger(H3Service.class);
+
+
+    private final boolean useH3;
+    private final int resolution;
+    private final H3Core core;
+
+    public H3Service(VaccineScheduleProperties properties) {
+        this.resolution = properties.getH3Resolution();
+        this.useH3 = properties.isUseH3Search();
+        try {
+            this.core = H3Core.newInstance();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        logger.debug("Setting H3 resolution {}", this.resolution);
+        if (this.useH3) {
+            logger.info("Using H3 methods for approximate searching");
+        } else {
+            logger.info("Not using H3 for searching");
+        }
+
+    }
+
+    /**
+     * Encodes the given point to an H3 index.
+     * Uses the resolution provided by the configuration
+     *
+     * @param point - {@link Point} to encode
+     * @return - {@link Long} H3 index of point
+     */
+    public long encodePoint(Point point) {
+        return this.core.geoToH3(point.getY(), point.getX(), this.resolution);
+    }
+
+    /**
+     * Return a {@link List} of H3 indexes which are approximately within the given distance of the point
+     *
+     * @param query - {@link NearestQuery} to use as search point
+     * @return - {@link List} of {@link Long} H3 indexes witin the radius
+     */
+    public List<Long> findNeighbors(NearestQuery query) {
+        final long encodedPoint = encodePoint(query.getPoint());
+        // Convert the distance to meters
+        final double searchMeters = query.getDistanceInMeters();
+        final int radius = (int) Math.floor(searchMeters / (core.edgeLength(this.resolution, LengthUnit.m) * 2));
+        try {
+            return this.core.hexRing(encodedPoint, radius);
+        } catch (PentagonEncounteredException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Whether or not to use the H3 indexes as the search method
+     *
+     * @return - {@code true} Use H3 for searching. {@code false} use normal spatial methods
+     */
+    public boolean useH3Search() {
+        return this.useH3;
+    }
+}

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/services/RollbarServerProvider.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/services/RollbarServerProvider.java
@@ -2,7 +2,7 @@ package gov.usds.vaccineschedule.api.services;
 
 import com.rollbar.api.payload.data.Server;
 import com.rollbar.notifier.provider.Provider;
-import gov.usds.vaccineschedule.api.properties.RollbarConfigurationProperties;
+import gov.usds.vaccineschedule.api.properties.RollbarConfigProperties;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
@@ -15,9 +15,9 @@ import org.springframework.stereotype.Component;
 public class RollbarServerProvider implements Provider<Server> {
 
     private final Environment env;
-    private final RollbarConfigurationProperties config;
+    private final RollbarConfigProperties config;
 
-    public RollbarServerProvider(Environment env, RollbarConfigurationProperties config) {
+    public RollbarServerProvider(Environment env, RollbarConfigProperties config) {
         this.env = env;
         this.config = config;
     }

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/services/ScheduledTaskService.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/services/ScheduledTaskService.java
@@ -1,6 +1,6 @@
 package gov.usds.vaccineschedule.api.services;
 
-import gov.usds.vaccineschedule.api.config.ScheduleSourceConfig;
+import gov.usds.vaccineschedule.api.properties.ScheduleSourceConfigProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.TaskScheduler;
@@ -28,7 +28,7 @@ public class ScheduledTaskService {
         this.fetcher = fetchService;
     }
 
-    public Map<String, ScheduledFuture<?>> scheduleFetch(ScheduleSourceConfig config) {
+    public Map<String, ScheduledFuture<?>> scheduleFetch(ScheduleSourceConfigProperties config) {
         Map<String, ScheduledFuture<?>> futures = new HashMap<>();
         // Ideally, we should have refresh schedules per source, but that's not necessary for an MVP.
         TimeZone tz = config.getScheduleTimezone();

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/services/SourceFetchService.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/services/SourceFetchService.java
@@ -3,7 +3,7 @@ package gov.usds.vaccineschedule.api.services;
 import ca.uhn.fhir.context.FhirContext;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
-import gov.usds.vaccineschedule.api.config.ScheduleSourceConfig;
+import gov.usds.vaccineschedule.api.properties.ScheduleSourceConfigProperties;
 import gov.usds.vaccineschedule.common.helpers.NDJSONToFHIR;
 import gov.usds.vaccineschedule.common.models.PublishResponse;
 import gov.usds.vaccineschedule.common.models.VaccineSlot;
@@ -45,7 +45,7 @@ public class SourceFetchService {
 
     private static final List<String> resourceOrder = ImmutableList.of("Location", "Schedule", "Slot");
 
-    private final ScheduleSourceConfig config;
+    private final ScheduleSourceConfigProperties config;
     private final NDJSONToFHIR converter;
     private final Sinks.Many<String> processor;
     private final LocationService locationService;
@@ -55,7 +55,7 @@ public class SourceFetchService {
 
     private Disposable disposable;
 
-    public SourceFetchService(FhirContext context, ScheduleSourceConfig config, LocationService locationService, ScheduleService sService, SlotService slService) {
+    public SourceFetchService(FhirContext context, ScheduleSourceConfigProperties config, LocationService locationService, ScheduleService sService, SlotService slService) {
         this.config = config;
         this.converter = new NDJSONToFHIR(context.newJsonParser());
         this.slService = slService;

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/services/geocoder/MapBoxGeocoderService.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/services/geocoder/MapBoxGeocoderService.java
@@ -1,7 +1,7 @@
 package gov.usds.vaccineschedule.api.services.geocoder;
 
-import gov.usds.vaccineschedule.api.config.GeocoderConfig;
 import gov.usds.vaccineschedule.api.db.models.AddressElement;
+import gov.usds.vaccineschedule.api.properties.GeocoderConfigProperties;
 import org.geojson.Feature;
 import org.geojson.FeatureCollection;
 import org.geojson.LngLatAlt;
@@ -20,9 +20,9 @@ import reactor.core.publisher.Mono;
 public class MapBoxGeocoderService implements GeocoderService {
     private static final Logger logger = LoggerFactory.getLogger(MapBoxGeocoderService.class);
 
-    private final GeocoderConfig config;
+    private final GeocoderConfigProperties config;
 
-    public MapBoxGeocoderService(GeocoderConfig config) {
+    public MapBoxGeocoderService(GeocoderConfigProperties config) {
         this.config = config;
     }
 

--- a/api-application/src/main/resources/application-heroku.yml
+++ b/api-application/src/main/resources/application-heroku.yml
@@ -26,7 +26,7 @@ rollbar:
   environment: heroku
   code-version: 0.0.1
 bucket4j:
-  enabled: true
+  enabled: false
   filters:
     - cache-name: buckets
       url: .*

--- a/api-application/src/main/resources/application.yml
+++ b/api-application/src/main/resources/application.yml
@@ -20,6 +20,8 @@ logging:
     ca.uhn.fhir.jaxrs: debug
     gov.usds: debug
 vs:
+  use-h3-search: true
+  h3-resolution: 8
   schedule-source:
     schedule-enabled: false
     upload-schedule: "0 0 11 * * *" # Daily at 11:00 AM Eastern Time

--- a/api-application/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/api-application/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -272,4 +272,24 @@ databaseChangeLog:
                   remarks: Slot capacity (defaults to 1 if not provided)
                   constraints:
                     nullable: false
+  - changeSet:
+      id: add-h3-index
+      author: nicholas.a.robison@omb.eop.gov
+      comment: Add H3 index for improving search performance
+      changes:
+        - addColumn:
+            tableName: locations
+            columns:
+              - column:
+                  name: h3_index
+                  type: bigint
+                  remarks: H3 hexagon index of location
+        - createIndex:
+            indexName: ck__locations__h3_index
+            tableName: locations
+            clustered: true
+            columns:
+              - column:
+                  name: h3_index
+
 

--- a/api-application/src/test/java/gov/usds/vaccineschedule/api/services/FetchServiceTest.java
+++ b/api-application/src/test/java/gov/usds/vaccineschedule/api/services/FetchServiceTest.java
@@ -2,7 +2,7 @@ package gov.usds.vaccineschedule.api.services;
 
 import ca.uhn.fhir.context.FhirContext;
 import gov.usds.vaccineschedule.api.BaseApplicationTest;
-import gov.usds.vaccineschedule.api.config.ScheduleSourceConfig;
+import gov.usds.vaccineschedule.api.properties.ScheduleSourceConfigProperties;
 import gov.usds.vaccineschedule.common.models.PublishResponse;
 import gov.usds.vaccineschedule.common.models.VaccineSlot;
 import okhttp3.mockwebserver.MockResponse;
@@ -72,7 +72,7 @@ public class FetchServiceTest extends BaseApplicationTest {
         lService = Mockito.mock(LocationService.class);
         scheduleService = Mockito.mock(ScheduleService.class);
         slotService = Mockito.mock(SlotService.class);
-        final ScheduleSourceConfig config = new ScheduleSourceConfig(false, List.of(baseUrl), Collections.emptyList(), TimeZone.getDefault(), 2);
+        final ScheduleSourceConfigProperties config = new ScheduleSourceConfigProperties(false, List.of(baseUrl), Collections.emptyList(), TimeZone.getDefault(), 2);
         service = new SourceFetchService(ctx, config, lService, scheduleService, slotService);
     }
 


### PR DESCRIPTION
By default, we're using the built-in Postgis functions for doing any of our spatial queries.

While that works, it puts all the burden on the DB and is relatively slow.

Since the FHIR spec allows the `near` operation to return results of approximate quality, we should be able to use Uber's H3 library to do the distance computing. Now, rather than doing a spatial intersection on each query, we simply compute the H3 polygons that are within the given point distance and do an `IN` query to return the filtered list from the DB.

This not only offloads the computation cost from the DB to the API service (which should scale nicely) but it also allows us to better cache the query results because queries are now more generalized as they occur at a lower spatial resolution than a single coordinate.

closes #5 