### PR TITLE
Add distance calculation to near query bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ curl --location --request GET 'http://localhost:8080/fhir/Location?near=42.4887%
 --header 'Content-Type: application/fhir+json'
 ```
 
+> Note: Supported distance units are miles (mi), kilometers (km) and meters (m).
+> Searches default to 50km distance from the given point.
+
 You can also look for slots within a period of time:
 
 ```bash

--- a/api-application/build.gradle
+++ b/api-application/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     implementation 'de.grundid.opendatalab:geojson-jackson:1.14'
     implementation 'org.hibernate:hibernate-spatial'
     implementation 'com.uber:h3:3.7.0'
+    implementation 'net.sf.geographiclib:GeographicLib-Java:1.51'
 
     // Unit conversion
     implementation 'tech.units:indriya:2.1.2'

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/db/models/LocationEntity.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/db/models/LocationEntity.java
@@ -178,7 +178,9 @@ public class LocationEntity extends BaseEntity implements Flammable<VaccineLocat
 
         // Add query distance, if it exists
         if (this.distanceFromPoint != null) {
-            final org.hl7.fhir.r4.model.Quantity fhirDistance = new org.hl7.fhir.r4.model.Quantity().setCode("km").setValue(distanceFromPoint.getValue().doubleValue());
+            final org.hl7.fhir.r4.model.Quantity fhirDistance = new org.hl7.fhir.r4.model.Quantity()
+                    .setCode(getUOMFromQuantity(distanceFromPoint))
+                    .setValue(distanceFromPoint.getValue().doubleValue());
             location.setLocationDistance(fhirDistance);
         }
         return location;
@@ -220,5 +222,15 @@ public class LocationEntity extends BaseEntity implements Flammable<VaccineLocat
             entity.setCoordinates(point);
         }
         return entity;
+    }
+
+    private static String getUOMFromQuantity(Quantity<Length> quantity) {
+        // We have to switch off the string unit value
+        // Which in some cases, is a unit conversion string from meters
+        final String s = quantity.getUnit().toString();
+        if ("(m*1609344)/1000".equals(s)) {
+            return "[mi_us]";
+        }
+        return s;
     }
 }

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/services/ExampleDataService.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/services/ExampleDataService.java
@@ -2,9 +2,9 @@ package gov.usds.vaccineschedule.api.services;
 
 import ca.uhn.fhir.context.FhirContext;
 import gov.usds.vaccineschedule.common.helpers.NDJSONToFHIR;
+import gov.usds.vaccineschedule.common.models.VaccineLocation;
 import gov.usds.vaccineschedule.common.models.VaccineSlot;
 import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.hl7.fhir.r4.model.Location;
 import org.hl7.fhir.r4.model.Schedule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,7 +51,7 @@ public class ExampleDataService {
     }
 
     private void loadLocations() {
-        loadResources(Location.class, "example-locations.ndjson", this.locService::addLocations);
+        loadResources(VaccineLocation.class, "example-locations.ndjson", this.locService::addLocations);
     }
 
     private void loadSchedules() {

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/services/SourceFetchService.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/services/SourceFetchService.java
@@ -6,9 +6,9 @@ import com.google.common.collect.ImmutableList;
 import gov.usds.vaccineschedule.api.properties.ScheduleSourceConfigProperties;
 import gov.usds.vaccineschedule.common.helpers.NDJSONToFHIR;
 import gov.usds.vaccineschedule.common.models.PublishResponse;
+import gov.usds.vaccineschedule.common.models.VaccineLocation;
 import gov.usds.vaccineschedule.common.models.VaccineSlot;
 import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.hl7.fhir.r4.model.Location;
 import org.hl7.fhir.r4.model.Schedule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -85,8 +85,8 @@ public class SourceFetchService {
     }
 
     private void processResource(IBaseResource resource) {
-        if (resource instanceof Location) {
-            this.locationService.addLocation((Location) resource);
+        if (resource instanceof VaccineLocation) {
+            this.locationService.addLocation((VaccineLocation) resource);
         } else if (resource instanceof Schedule) {
             this.sService.addSchedule((Schedule) resource);
         } else if (resource instanceof VaccineSlot) {

--- a/api-application/src/test/java/gov/usds/vaccineschedule/api/services/TestLocationService.java
+++ b/api-application/src/test/java/gov/usds/vaccineschedule/api/services/TestLocationService.java
@@ -4,6 +4,7 @@ import ca.uhn.fhir.parser.IParser;
 import ca.uhn.fhir.rest.param.TokenParam;
 import gov.usds.vaccineschedule.api.BaseApplicationTest;
 import gov.usds.vaccineschedule.common.helpers.NDJSONToFHIR;
+import gov.usds.vaccineschedule.common.models.VaccineLocation;
 import org.hl7.fhir.r4.model.Location;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,7 +35,7 @@ public class TestLocationService extends BaseApplicationTest {
 
         // Pull a single location out of the NDJSON file
         final InputStream is = TestLocationService.class.getClassLoader().getResourceAsStream("example-locations.ndjson");
-        final Location firstLoc = converter.inputStreamToTypedResource(Location.class, is).get(0);
+        final VaccineLocation firstLoc = converter.inputStreamToTypedResource(VaccineLocation.class, is).get(0);
 
         // Pull out the location to cache it
         final TokenParam tokenParam = new TokenParam().setSystem(ORIGINAL_ID_SYSTEM).setValue(firstLoc.getId());
@@ -55,7 +56,7 @@ public class TestLocationService extends BaseApplicationTest {
         final IParser parser = ctx.newJsonParser();
         final NDJSONToFHIR converter = new NDJSONToFHIR(parser);
         final InputStream is = TestLocationService.class.getClassLoader().getResourceAsStream("example-locations.ndjson");
-        final List<Location> locations = converter.inputStreamToTypedResource(Location.class, is);
+        final List<VaccineLocation> locations = converter.inputStreamToTypedResource(VaccineLocation.class, is);
         this.service.addLocations(locations);
         assertEquals(origCount, this.service.countLocations(null, null, null, null), "Count should not change");
     }

--- a/api-application/src/test/java/gov/usds/vaccineschedule/api/utils/FhirHandlers.java
+++ b/api-application/src/test/java/gov/usds/vaccineschedule/api/utils/FhirHandlers.java
@@ -1,7 +1,9 @@
 package gov.usds.vaccineschedule.api.utils;
 
 import ca.uhn.fhir.rest.client.api.IGenericClient;
+import gov.usds.vaccineschedule.common.models.VaccineLocation;
 import gov.usds.vaccineschedule.common.models.VaccineSlot;
+import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Resource;
 import org.junit.jupiter.api.Assertions;
@@ -15,17 +17,17 @@ import java.util.List;
  */
 public class FhirHandlers {
 
+    public static final List<Class<? extends IBaseResource>> customTypes = List.of(VaccineSlot.class, VaccineLocation.class);
+
     @SuppressWarnings("unchecked")
     public static <T extends Resource> List<T> unwrapBundle(IGenericClient client, Bundle bundle, Date searchTime) {
-        int idx = 0;
         assertBundleUpdatedBefore(bundle, searchTime);
         List<T> resources = new ArrayList<>();
         // Loop through all the pages
         bundle.getEntry().forEach(e -> resources.add((T) e.getResource()));
 
         while (bundle.getLink(Bundle.LINK_NEXT) != null) {
-            idx++;
-            bundle = client.loadPage().next(bundle).preferResponseType(VaccineSlot.class).execute();
+            bundle = client.loadPage().next(bundle).preferResponseTypes(customTypes).execute();
             assertBundleUpdatedBefore(bundle, searchTime);
             bundle.getEntry().forEach(e -> resources.add((T) e.getResource()));
         }

--- a/api-application/src/test/java/gov/usds/vaccineschedule/api/utils/HelperAssertions.java
+++ b/api-application/src/test/java/gov/usds/vaccineschedule/api/utils/HelperAssertions.java
@@ -1,0 +1,16 @@
+package gov.usds.vaccineschedule.api.utils;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Created by nickrobison on 4/9/21
+ */
+public class HelperAssertions {
+
+    public static void assertBDApproxEqual(BigDecimal exp, BigDecimal obs, double epsilon) {
+        final BigDecimal eps = BigDecimal.valueOf(epsilon);
+        assertTrue(exp.subtract(obs).abs().compareTo(eps) < 0, String.format("`%s` is not within `%.2f` of `%s`", obs.toString(), epsilon, exp.toString()));
+    }
+}

--- a/common/src/main/java/gov/usds/vaccineschedule/common/models/VaccineLocation.java
+++ b/common/src/main/java/gov/usds/vaccineschedule/common/models/VaccineLocation.java
@@ -1,0 +1,34 @@
+package gov.usds.vaccineschedule.common.models;
+
+import ca.uhn.fhir.model.api.annotation.Child;
+import ca.uhn.fhir.model.api.annotation.Description;
+import ca.uhn.fhir.model.api.annotation.Extension;
+import ca.uhn.fhir.model.api.annotation.ResourceDef;
+import org.hl7.fhir.r4.model.Location;
+import org.hl7.fhir.r4.model.Quantity;
+
+/**
+ * Created by nickrobison on 4/9/21
+ */
+@ResourceDef(name = "Location", profile = "http://fhir-registry.smarthealthit.org/StructureDefinition/vaccine-location")
+public class VaccineLocation extends Location {
+    private static final long serialVersionUID = 42L;
+
+    @Extension(url = "http://hl7.org/fhir/StructureDefinition/location-distance", isModifier = false, definedLocally = false)
+    @Description(shortDefinition = "A calculated distance between the resource and a provided location")
+    @Child(name = "locationDistance")
+    private Quantity locationDistance;
+
+    public Quantity getLocationDistance() {
+        if (locationDistance == null) {
+            locationDistance = new Quantity();
+        }
+        return locationDistance;
+    }
+
+    public void setLocationDistance(Quantity quantity) {
+        this.locationDistance = quantity;
+    }
+
+
+}

--- a/resources/definitions/vaccine-location.json
+++ b/resources/definitions/vaccine-location.json
@@ -8,6 +8,37 @@
   "differential": {
     "element": [
       {
+        "id": "Location",
+        "path": "Location",
+        "min": 1,
+        "max": 1
+      },
+      {
+        "id": "Location.extension",
+        "path": "Location.extension",
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "value",
+              "path": "url"
+            }
+          ],
+          "ordered": false,
+          "rules": "open"
+        }
+      },
+      {
+        "id": "Location.extension:distance-extension",
+        "path": "Location.extension",
+        "sliceName": "distance-extension",
+        "type": [
+          {
+            "code": "Extension",
+            "profile": "http://hl7.org/fhir/StructureDefinition/location-distance"
+          }
+        ]
+      },
+      {
         "id": "Location.name",
         "path": "Location.name",
         "definition": "Location name",
@@ -71,30 +102,6 @@
         ],
         "min": 1,
         "max": "1"
-      },
-      {
-        "id": "Location.extension",
-        "path": "Location.extension",
-        "slicing": {
-          "discriminator": [
-            {
-              "type": "value",
-              "path": "url"
-            }
-          ],
-          "rules": "open"
-        }
-      },
-      {
-        "id": "Location.extension:distance-extension",
-        "path": "Location.extension",
-        "sliceName": "distance-extension",
-        "type": [
-          {
-            "code": "Extension",
-            "profile": "http://hl7.org/fhir/StructureDefinition/location-distance"
-          }
-        ]
       }
     ]
   }

--- a/resources/definitions/vaccine-location.json
+++ b/resources/definitions/vaccine-location.json
@@ -71,6 +71,30 @@
         ],
         "min": 1,
         "max": "1"
+      },
+      {
+        "id": "Location.extension",
+        "path": "Location.extension",
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "value",
+              "path": "url"
+            }
+          ],
+          "rules": "open"
+        }
+      },
+      {
+        "id": "Location.extension:distance-extension",
+        "path": "Location.extension",
+        "sliceName": "distance-extension",
+        "type": [
+          {
+            "code": "Extension",
+            "profile": "http://hl7.org/fhir/StructureDefinition/location-distance"
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
When a user performs a `near` search for Locations, we should calculate the distance between the query point and the returned locations.

Ideally, these values should be in the units that the user performed the search (e.g. miles, km, etc).

Created a custom `VaccineLocation` class which holds the FHIR `distance` extension, we're now passing that class around the application, just like we already do with `VaccineSlot`.

Updated the Location structure definition to include the new extension information.

closes #48 