### PR TITLE
Remove command from API container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,6 @@ services:
       - "${VS_PUBLISHER_PORT:-9090}:9090"
   api:
     image: ghcr.io/nickrobison-usds/vaccine-schedule/api
-    command: bootRun
     depends_on:
       - db
       - rabbitmq


### PR DESCRIPTION
We don't need `bootRun` anymore in our API container, because Jib figures it all out on its own.