### PR TITLE
Migrate Docker Images to Docker Hub

### DIFF
--- a/.github/workflows/deployDocker.yml
+++ b/.github/workflows/deployDocker.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - '**'
+      - main
 
 jobs:
   deploy:

--- a/.github/workflows/deployDocker.yml
+++ b/.github/workflows/deployDocker.yml
@@ -4,9 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
-    paths:
-      - .github/workflows/deployDocker.yml
+      - '**'
 
 jobs:
   deploy:
@@ -26,7 +24,7 @@ jobs:
             ~/.gradle/wrapper
           key: gradle-build-${{ hashFiles('*.gradle') }}
       - name: Docker Login
-        run: echo "${{ secrets.DOCKER_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+        run: echo "${{ secrets.DOCKER_TOKEN }}" | docker login -u nickrobisonusds --password-stdin
       - name: Build and Push Docker
         run: ./gradlew jib
 

--- a/api-application/build.gradle
+++ b/api-application/build.gradle
@@ -15,7 +15,7 @@ dependencyManagement {
 
 jib {
     from.image = fromImage
-    to.image = "${imageRoot}/api"
+    to.image = "${imageRoot}/vs-api"
     container {
         ports ['8080']
     }

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 ext {
     hapiVersion = '5.3.2'
     fromImage = 'gcr.io/distroless/java:11'
-    imageRoot = 'ghcr.io/nickrobison-usds/vaccine-schedule'
+    imageRoot = 'nickrobisonusds'
 }
 
 allprojects {

--- a/publisher-application/build.gradle
+++ b/publisher-application/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.google.cloud.tools.jib'
 
 jib {
     from.image  = fromImage
-    to.image = "${imageRoot}/publisher"
+    to.image = "${imageRoot}/vs-publisher"
 
     container {
         ports ['9090']


### PR DESCRIPTION
Since GHCR doesn't support unauthenticated access, we need to move our containers to Docker hub, in order to make them available more broadly.