### PR TITLE
Update currentAsOf to match FHIR-I standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,15 +94,15 @@ Resources returned by the API contain two timestamps:
 
 1. `lastUpdatedAt` in the `Meta` component indicates the update timestamp provided by the upstream server (if one
    exists).
-1. `currentAsOf` as an extension in the `Meta` component which indicates when the resource was updated in the API
+1. `lastSourceSync` as an extension in the `Meta` component which indicates when the resource was updated in the API
    server (e.g. fetched from upstream). This value is always provided and is set regardless of whether or not any values
    have changed from upstream. Users can retrieve this value via
-   the `http://usds.gov/vaccine/currentAsOf` system.
+   the `http://hl7.org/fhir/StructureDefinition/lastSourceSync` system.
 
-The means the `lastUpdatedAt` can significantly lag behind `currentAsOf` if the upstream source refreshes their data at
-a slower interval than which the API server looks for new values.
+The means the `lastUpdatedAt` can significantly lag behind `lastSourceSync` if the upstream source refreshes their data
+at a slower interval than which the API server looks for new values.
 
-When returning a `Bundle` resource, the `lastUpdatedAt` value is set to either the maximum `currentAsOf` time for the
+When returning a `Bundle` resource, the `lastUpdatedAt` value is set to either the maximum `lastSourceSync` time for the
 bundled resources, or to the transaction timestamp.
 
 ### Refreshing the data:

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/db/models/UpstreamUpdateableEntity.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/db/models/UpstreamUpdateableEntity.java
@@ -9,8 +9,8 @@ import javax.persistence.Column;
 import javax.persistence.MappedSuperclass;
 import java.time.OffsetDateTime;
 
-import static gov.usds.vaccineschedule.common.Constants.CURRENT_AS_OF;
 import static gov.usds.vaccineschedule.common.Constants.FHIR_FORMATTER;
+import static gov.usds.vaccineschedule.common.Constants.LAST_SOURCE_SYNC;
 
 /**
  * Created by nickrobison on 4/14/21
@@ -37,7 +37,7 @@ public abstract class UpstreamUpdateableEntity extends BaseEntity {
         if (this.getUpdatedAt() != null) {
             final String fhirDateString = this.getUpdatedAt().format(FHIR_FORMATTER);
             final InstantType currentTimestamp = new InstantType(fhirDateString);
-            meta.addExtension(new Extension(CURRENT_AS_OF, currentTimestamp));
+            meta.addExtension(new Extension(LAST_SOURCE_SYNC, currentTimestamp));
         }
 
         return meta;

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/models/BundleFactory.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/models/BundleFactory.java
@@ -18,7 +18,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import static gov.usds.vaccineschedule.common.Constants.CURRENT_AS_OF;
+import static gov.usds.vaccineschedule.common.Constants.LAST_SOURCE_SYNC;
 import static gov.usds.vaccineschedule.common.helpers.DateUtils.offsetDateTimeToDate;
 
 /**
@@ -66,7 +66,7 @@ public class BundleFactory {
     private static @Nullable
     Date getCurrentDate(IBaseResource r) {
         if (r.getMeta() instanceof Meta) {
-            final Extension extension = ((Meta) r.getMeta()).getExtensionByUrl(CURRENT_AS_OF);
+            final Extension extension = ((Meta) r.getMeta()).getExtensionByUrl(LAST_SOURCE_SYNC);
             final InstantType instantType = extension.getValue().castToInstant(extension.getValue());
             final OffsetDateTime offsetDateTime = OffsetDateTime.parse(instantType.getValueAsString(), Constants.FHIR_FORMATTER);
             return offsetDateTimeToDate(offsetDateTime);

--- a/api-application/src/test/java/gov/usds/vaccineschedule/api/services/TestLocationService.java
+++ b/api-application/src/test/java/gov/usds/vaccineschedule/api/services/TestLocationService.java
@@ -18,7 +18,7 @@ import java.io.InputStream;
 import java.sql.Date;
 import java.util.List;
 
-import static gov.usds.vaccineschedule.common.Constants.CURRENT_AS_OF;
+import static gov.usds.vaccineschedule.common.Constants.LAST_SOURCE_SYNC;
 import static gov.usds.vaccineschedule.common.Constants.ORIGINAL_ID_SYSTEM;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -70,7 +70,7 @@ public class TestLocationService extends BaseApplicationTest {
     }
 
     private static InstantType getCurrentTimestamp(Location location) {
-        final Type value = location.getMeta().getExtensionByUrl(CURRENT_AS_OF).getValue();
+        final Type value = location.getMeta().getExtensionByUrl(LAST_SOURCE_SYNC).getValue();
         return value.castToInstant(value);
     }
 

--- a/common/src/main/java/gov/usds/vaccineschedule/common/Constants.java
+++ b/common/src/main/java/gov/usds/vaccineschedule/common/Constants.java
@@ -32,13 +32,13 @@ public class Constants {
     public static final String SCHEDULE_PROFILE = "http://fhir-registry.smarthealthit.org/StructureDefinition/vaccine-schedule";
 
     // Extensions
-    public static String ORIGINAL_ID_SYSTEM = "http://usds.gov/vaccine/source-identifier";
-    public static String LAST_SOURCE_SYNC = "http://hl7.org/fhir/StructureDefinition/lastSourceSync";
+    public static final String ORIGINAL_ID_SYSTEM = "http://usds.gov/vaccine/source-identifier";
+    public static final String LAST_SOURCE_SYNC = "http://hl7.org/fhir/StructureDefinition/lastSourceSync";
 
     public static final String HL7_SYSTEM = "http://terminology.hl7.org/CodeSystem/service-type";
     public static final String SMART_SYSTEM = "http://fhir-registry.smarthealthit.org/CodeSystem/service-type";
     // Schedule Identifiers
-    public static Identifier HL7_IDENTIFIER = new Identifier().setSystem(HL7_SYSTEM).setValue("57");
+    public static final Identifier HL7_IDENTIFIER = new Identifier().setSystem(HL7_SYSTEM).setValue("57");
 
-    public static Identifier SMART_IDENTIFIER = new Identifier().setSystem(SMART_SYSTEM).setValue("covid19-immunization");
+    public static final Identifier SMART_IDENTIFIER = new Identifier().setSystem(SMART_SYSTEM).setValue("covid19-immunization");
 }

--- a/common/src/main/java/gov/usds/vaccineschedule/common/Constants.java
+++ b/common/src/main/java/gov/usds/vaccineschedule/common/Constants.java
@@ -33,7 +33,7 @@ public class Constants {
 
     // Extensions
     public static String ORIGINAL_ID_SYSTEM = "http://usds.gov/vaccine/source-identifier";
-    public static String CURRENT_AS_OF = "http://usds.gov/vaccine/currentAsOf";
+    public static String LAST_SOURCE_SYNC = "http://hl7.org/fhir/StructureDefinition/lastSourceSync";
 
     public static final String HL7_SYSTEM = "http://terminology.hl7.org/CodeSystem/service-type";
     public static final String SMART_SYSTEM = "http://fhir-registry.smarthealthit.org/CodeSystem/service-type";


### PR DESCRIPTION
The FHIR spec now has (or will have) a standard for indicating last sync using `lastSourceSync`

Simple fix on our end to add support for that.