### PR TITLE
Deploy Washington Publisher Service to Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,0 @@
-web: java -Dserver.port=$PORT -Dspring.profiles.active="heroku" $JAVA_OPTS -jar api-application/build/libs/api-application-0.0.1-SNAPSHOT.jar
-publisher: java -Dserver.port=$PORT -Dspring.profiles.active="heroku" $JAVA_OPTS -jar wa-publisher/build/libs/wa-publisher-0.0.1-SNAPSHOT.jar

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: java -Dserver.port=$PORT -Dspring.profiles.active="heroku" $JAVA_OPTS -jar api-application/build/libs/api-application-0.0.1-SNAPSHOT.jar
+publisher: java -Dserver.port=$PORT -Dspring.profiles.active="heroku" $JAVA_OPTS -jar wa-publisher/build/libs/wa-publisher-0.0.1-SNAPSHOT.jar

--- a/api-application/Procfile
+++ b/api-application/Procfile
@@ -1,1 +1,1 @@
-web: java -Dserver.port=$PORT -Dspring.profiles.active="heroku" $JAVA_OPTS -jar build/libs/api-application-0.0.1-SNAPSHOT.jar
+web: java -Dserver.port=$PORT -Dspring.profiles.active="heroku" $JAVA_OPTS -jar api-application/build/libs/api-application-0.0.1-SNAPSHOT.jar

--- a/api-application/Procfile
+++ b/api-application/Procfile
@@ -1,0 +1,1 @@
+web: java -Dserver.port=$PORT -Dspring.profiles.active="heroku" $JAVA_OPTS -jar build/libs/api-application-0.0.1-SNAPSHOT.jar

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ subprojects {
 }
 
 task stage {
-    dependsOn(['clean', ':api-application:assemble'])
+    dependsOn(['clean', ':api-application:assemble', ':wa-publisher:assemble'])
     assemble.mustRunAfter clean
     doLast {
         delete(fileTree(dir: "api-application/build", exclude: "libs"))
@@ -52,6 +52,9 @@ task stage {
 
         delete(fileTree(dir: "publisher-application/build", exclude: "libs"))
         delete(fileTree(dir: "publisher-application/build/libs", exclude: "*.jar"))
+
+        delete(fileTree(dir: "wa-publisher/build", exclude: "libs"))
+        delete(fileTree(dir: "wa-publisher/build/libs", exclude: "*.jar"))
 
         delete(fileTree(dir: "common/build", exclude: "libs"))
         delete(fileTree(dir: "common/build/libs", exclude: "*.jar"))

--- a/wa-publisher/Procfile
+++ b/wa-publisher/Procfile
@@ -1,0 +1,1 @@
+web: java -Dserver.port=$PORT -Dspring.profiles.active="heroku" $JAVA_OPTS -jar build/libs/wa-publisher-0.0.1-SNAPSHOT.jar

--- a/wa-publisher/Procfile
+++ b/wa-publisher/Procfile
@@ -1,1 +1,1 @@
-web: java -Dserver.port=$PORT -Dspring.profiles.active="heroku" $JAVA_OPTS -jar build/libs/wa-publisher-0.0.1-SNAPSHOT.jar
+web: java -Dserver.port=$PORT -Dspring.profiles.active="heroku" $JAVA_OPTS -jar wa-publisher/build/libs/wa-publisher-0.0.1-SNAPSHOT.jar

--- a/wa-publisher/build.gradle
+++ b/wa-publisher/build.gradle
@@ -37,6 +37,6 @@ dependencies {
     }
 }
 
-processResources {
-    from("$rootDir/examples")
+springBoot {
+    buildInfo()
 }


### PR DESCRIPTION
Update Heroku config to deploy WA Publisher alongside the API application.

This is accomplished via the Heroku multi-app Buildpack, which is pretty simple to get up and running.
Also disabled Liquibase on the API service, which makes starting the app MUCH quicker and more reliable. We'll just need to make sure we run any required migrations manually before deploying. Which seems ok for now.