### PR TITLE
Update WA Publisher baseURL

### DIFF
--- a/wa-publisher/src/main/resources/application-heroku.yml
+++ b/wa-publisher/src/main/resources/application-heroku.yml
@@ -1,0 +1,2 @@
+publisher:
+  baseUrl: https://midnight-contender-wa-publish.herokuapp.com


### PR DESCRIPTION
We're now returning the correct URL for the application when running in Heroku.

While working on this, I noticed that the request URL is returning a relative link, rather than absolute. That's annoying but I didn't fix it in this PR because it's not a huge issue and that would cause our Sonar rules to fail, which would prevent the deployment.

closes #89 