### PR TITLE
Add USDR and WA publishers to API upstreams

### DIFF
--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/exceptions/MissingUpstreamResource.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/exceptions/MissingUpstreamResource.java
@@ -1,0 +1,26 @@
+package gov.usds.vaccineschedule.api.exceptions;
+
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.Identifier;
+
+/**
+ * Created by nickrobison on 4/21/21
+ */
+public class MissingUpstreamResource extends RuntimeException {
+
+    private final Class<? extends IBaseResource> resourceType;
+    private final Identifier resourceIdentifier;
+
+    public MissingUpstreamResource(Class<? extends IBaseResource> resourceType, Identifier resourceIdentifier) {
+        this.resourceType = resourceType;
+        this.resourceIdentifier = resourceIdentifier;
+    }
+
+    public Class<? extends IBaseResource> getResourceType() {
+        return resourceType;
+    }
+
+    public Identifier getResourceIdentifier() {
+        return resourceIdentifier;
+    }
+}

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/services/ScheduleService.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/services/ScheduleService.java
@@ -8,10 +8,13 @@ import ca.uhn.fhir.validation.ValidationOptions;
 import ca.uhn.fhir.validation.ValidationResult;
 import gov.usds.vaccineschedule.api.db.models.LocationEntity;
 import gov.usds.vaccineschedule.api.db.models.ScheduleEntity;
+import gov.usds.vaccineschedule.api.exceptions.MissingUpstreamResource;
 import gov.usds.vaccineschedule.api.repositories.LocationRepository;
 import gov.usds.vaccineschedule.api.repositories.ScheduleRepository;
 import gov.usds.vaccineschedule.common.Constants;
+import gov.usds.vaccineschedule.common.models.VaccineLocation;
 import org.hl7.fhir.instance.model.api.IIdType;
+import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Schedule;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -100,7 +103,7 @@ public class ScheduleService {
         final String reference = resource.getActor().get(0).getReference();
         final List<LocationEntity> locations = lRepo.findAll(LocationRepository.hasIdentifier(ORIGINAL_ID_SYSTEM, reference));
         if (locations.isEmpty()) {
-            throw new IllegalStateException("Cannot add to missing location");
+            throw new MissingUpstreamResource(VaccineLocation.class, new Identifier().setSystem(ORIGINAL_ID_SYSTEM).setValue(reference));
         }
         final ScheduleEntity entity = ScheduleEntity.fromFHIR(locations.get(0), resource);
 

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/services/SlotService.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/services/SlotService.java
@@ -10,10 +10,13 @@ import ca.uhn.fhir.validation.ValidationOptions;
 import ca.uhn.fhir.validation.ValidationResult;
 import gov.usds.vaccineschedule.api.db.models.ScheduleEntity;
 import gov.usds.vaccineschedule.api.db.models.SlotEntity;
+import gov.usds.vaccineschedule.api.exceptions.MissingUpstreamResource;
 import gov.usds.vaccineschedule.api.repositories.ScheduleRepository;
 import gov.usds.vaccineschedule.api.repositories.SlotRepository;
 import gov.usds.vaccineschedule.common.Constants;
 import gov.usds.vaccineschedule.common.models.VaccineSlot;
+import org.hl7.fhir.r4.model.Identifier;
+import org.hl7.fhir.r4.model.Schedule;
 import org.hl7.fhir.r4.model.Slot;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
@@ -104,7 +107,7 @@ public class SlotService {
 
         final List<ScheduleEntity> schedule = new ArrayList<>(scheduleRepository.findAll(ScheduleRepository.hasIdentifier(ORIGINAL_ID_SYSTEM, scheduleRef)));
         if (schedule.isEmpty()) {
-            throw new IllegalStateException("Cannot add to missing schedule");
+            throw new MissingUpstreamResource(Schedule.class, new Identifier().setSystem(ORIGINAL_ID_SYSTEM).setValue(scheduleRef));
         }
 
         final SlotEntity entity = SlotEntity.fromFHIR(schedule.get(0), resource);

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/services/SourceFetchService.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/services/SourceFetchService.java
@@ -1,6 +1,7 @@
 package gov.usds.vaccineschedule.api.services;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.validation.ValidationFailureException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import gov.usds.vaccineschedule.api.properties.ScheduleSourceConfigProperties;
@@ -109,7 +110,11 @@ public class SourceFetchService {
                 .publishOn(this.dbScheduler)
                 .subscribe(resource -> {
                     logger.debug("Received resource: {}", resource);
-                    this.processResource(resource);
+                    try {
+                        this.processResource(resource);
+                    } catch (ValidationFailureException e) {
+                        logger.error("Resource failed validation. continuing", e);
+                    }
                 }, (error) -> {
                     throw new RuntimeException(error);
                 }, () -> logger.info("Finished refreshing data for {}", source));
@@ -141,9 +146,8 @@ public class SourceFetchService {
                 .baseUrl(baseURL)
                 // Configure Jackson to handle text/plain content types as well, such as what we get from Github
                 .codecs(configurer -> {
-                    // This API returns JSON with content type text/plain, so need to register a custom
+                    // An API may return JSON with content type text/plain, so need to register a custom
                     // decoder to deserialize this response via Jackson
-
                     // Get existing decoder's ObjectMapper if available, or create new one
                     ObjectMapper objectMapper = configurer.getReaders().stream()
                             .filter(reader -> reader instanceof Jackson2JsonDecoder)
@@ -153,7 +157,11 @@ public class SourceFetchService {
                             .orElseGet(() -> Jackson2ObjectMapperBuilder.json().build());
 
                     Jackson2JsonDecoder decoder = new Jackson2JsonDecoder(objectMapper, MediaType.TEXT_PLAIN);
+                    // Bump up the maximum data size to 1 MB
+                    decoder.setMaxInMemorySize(1024 * 1024 * 1024);
+                    configurer.defaultCodecs().maxInMemorySize(1024 * 1024 * 1024);
                     configurer.customCodecs().registerWithDefaultConfig(decoder);
+                    // Increase memory size to allow for big payloads
                 })
                 .build();
     }

--- a/api-application/src/main/resources/application-heroku.yml
+++ b/api-application/src/main/resources/application-heroku.yml
@@ -5,7 +5,8 @@ vs:
     upload-schedule: "0 0 11 * * *" # Daily at 11:00 AM Eastern Time
     upload-timezone: America/New_York
     sources:
-      - "https://raw.githubusercontent.com/smart-on-fhir/smart-scheduling-links/master/examples/"
+      - "https://midnight-contender-wa-publish.herokuapp.com"
+      - "http://getmyvax.org/smart-scheduling"
     db-thread-pool-size: 2
   baseUrl: https://midnight-contender.herokuapp.com
 spring:

--- a/api-application/src/test/java/gov/usds/vaccineschedule/api/services/FetchServiceTest.java
+++ b/api-application/src/test/java/gov/usds/vaccineschedule/api/services/FetchServiceTest.java
@@ -4,13 +4,13 @@ import ca.uhn.fhir.context.FhirContext;
 import gov.usds.vaccineschedule.api.BaseApplicationTest;
 import gov.usds.vaccineschedule.api.properties.ScheduleSourceConfigProperties;
 import gov.usds.vaccineschedule.common.models.PublishResponse;
+import gov.usds.vaccineschedule.common.models.VaccineLocation;
 import gov.usds.vaccineschedule.common.models.VaccineSlot;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.apache.commons.io.IOUtils;
 import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.hl7.fhir.r4.model.Location;
 import org.hl7.fhir.r4.model.Schedule;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -132,12 +132,12 @@ public class FetchServiceTest extends BaseApplicationTest {
         assertEquals(90, resources.size(), "Should have resources");
 
         // Verify the order is correct
-        final Optional<IBaseResource> nonLocations = resources.subList(0, 10).stream().filter(r -> !r.getClass().equals(Location.class)).findAny();
-        assertTrue(nonLocations.isEmpty(), "Should not have locations");
+        final Optional<IBaseResource> nonLocations = resources.subList(0, 10).stream().filter(r -> !r.getClass().equals(VaccineLocation.class)).findAny();
+        assertTrue(nonLocations.isEmpty(), "Should only have locations");
         final Optional<IBaseResource> nonSchedules = resources.subList(10, 20).stream().filter(r -> !r.getClass().equals(Schedule.class)).findAny();
-        assertTrue(nonSchedules.isEmpty(), "Should not have schedules");
+        assertTrue(nonSchedules.isEmpty(), "Should only have schedules");
         final Optional<IBaseResource> nonSlots = resources.subList(20, 90).stream().filter(r -> !r.getClass().equals(VaccineSlot.class)).findAny();
-        assertTrue(nonSlots.isEmpty(), "Should not have slots");
+        assertTrue(nonSlots.isEmpty(), "Should only have slots");
 
 
         // First, locations

--- a/common/src/main/java/gov/usds/vaccineschedule/common/helpers/NDJSONToFHIR.java
+++ b/common/src/main/java/gov/usds/vaccineschedule/common/helpers/NDJSONToFHIR.java
@@ -1,6 +1,7 @@
 package gov.usds.vaccineschedule.common.helpers;
 
 import ca.uhn.fhir.parser.IParser;
+import gov.usds.vaccineschedule.common.models.VaccineLocation;
 import gov.usds.vaccineschedule.common.models.VaccineSlot;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.slf4j.Logger;
@@ -11,7 +12,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -26,7 +26,7 @@ public class NDJSONToFHIR {
 
     public NDJSONToFHIR(IParser parser) {
         this.parser = parser;
-        this.parser.setPreferTypes(Collections.singletonList(VaccineSlot.class));
+        this.parser.setPreferTypes(List.of(VaccineLocation.class, VaccineSlot.class));
     }
 
     /**

--- a/wa-publisher/src/main/java/gov/usds/vaccineschedule/wapublisher/providers/BulkPublishProvider.java
+++ b/wa-publisher/src/main/java/gov/usds/vaccineschedule/wapublisher/providers/BulkPublishProvider.java
@@ -32,7 +32,7 @@ public class BulkPublishProvider {
 
         final PublishResponse publishResponse = new PublishResponse();
         publishResponse.setTransactionTime(OffsetDateTime.now());
-        publishResponse.setRequest("/$bulk-publish");
+        publishResponse.setRequest(String.format("%s/$bulk-publish", this.properties.getBaseURL()));
         publishResponse.setOutput(output);
 
         return publishResponse;

--- a/wa-publisher/src/main/java/gov/usds/vaccineschedule/wapublisher/services/UpstreamService.java
+++ b/wa-publisher/src/main/java/gov/usds/vaccineschedule/wapublisher/services/UpstreamService.java
@@ -129,6 +129,7 @@ public class UpstreamService {
         addIfNotNull(address::setCity, waLoc::getCity);
         addIfNotNull(address::setState, waLoc::getState);
         addIfNotNull(address::setPostalCode, waLoc::getZipcode);
+        location.setAddress(address);
 
         // Position
         final Location.LocationPositionComponent position = new Location.LocationPositionComponent()
@@ -176,6 +177,7 @@ public class UpstreamService {
         final Meta meta = new Meta();
         meta.setLastUpdated(offsetDateTimeToDate(location.getUpdatedAt()));
         slot.setMeta(meta);
+        slot.setId(location.getLocationId());
         if (location.getSchedulingLink() != null) {
             slot.setBookingUrl(new UrlType(location.getSchedulingLink()));
         }

--- a/wa-publisher/src/main/resources/application-dockerized.yml
+++ b/wa-publisher/src/main/resources/application-dockerized.yml
@@ -1,0 +1,2 @@
+publisher:
+  base-url: http://wa-publisher:${server.port}


### PR DESCRIPTION
Fetch data from WA publisher and USDR endpoints.

Fixed some bugs in the WA publisher which was causing it to return invalid data (e.g. missing Location addresses and slot IDs).

Improved the handling of validation errors.
Now, we just log the error and continue. As opposed to falling over when something doesn't go our way.