### PR TITLE
Use SSL for `getmyvax.org`

### DIFF
--- a/api-application/src/main/resources/application-dev.yml
+++ b/api-application/src/main/resources/application-dev.yml
@@ -11,7 +11,7 @@ vs:
     schedule-enabled: false
     sources:
       - "https://midnight-contender-wa-publish.herokuapp.com"
-      - "http://getmyvax.org/smart-scheduling"
+      - "https://getmyvax.org/smart-scheduling"
 logging:
   level:
     ca.uhn.fhir.jaxrs: debug

--- a/api-application/src/main/resources/application-heroku.yml
+++ b/api-application/src/main/resources/application-heroku.yml
@@ -6,7 +6,7 @@ vs:
     upload-timezone: America/New_York
     sources:
       - "https://midnight-contender-wa-publish.herokuapp.com"
-      - "http://getmyvax.org/smart-scheduling"
+      - "https://getmyvax.org/smart-scheduling"
       - "https://api.carbonhealth.com/hib/publicVaccination"
     db-thread-pool-size: 2
   baseUrl: https://midnight-contender.herokuapp.com


### PR DESCRIPTION
You should be able to access resources on `getmyvax.org` via HTTPS. I haven’t tested this PR, though!

(Were there any certificate issues that led you to using `http`?)