### PR TITLE
Add notifications when waiting for the Heroku backend to come alive

### DIFF
--- a/vs-ui/src/App.tsx
+++ b/vs-ui/src/App.tsx
@@ -1,13 +1,14 @@
 import React from "react";
 import { BrowserRouter, Route, Switch } from "react-router-dom";
 
-import "./App.css";
 import { NavMenu } from "./components/NavMenu/NavMenu";
 import { Home } from "./pages/Home/Home";
 import { Validate } from "./pages/Validate/Validate";
 import { Finder } from "./pages/Finder/Finder";
 import { FhirClientProvider } from "./providers/FhirClientProvider";
 import { Sources } from "./pages/Sources/Sources";
+
+import "./App.css";
 
 function App() {
   return (

--- a/vs-ui/src/components/GlobalAlert/GlobalAlert.scss
+++ b/vs-ui/src/components/GlobalAlert/GlobalAlert.scss
@@ -1,0 +1,11 @@
+.vs-alert {
+  position: absolute;
+  top: 0;
+  right: 0;
+  display: flex;
+  justify-content: space-around;
+  margin-top: 1vh;
+  margin-right: 1vh;
+  width: 40vh;
+  z-index: 10;
+}

--- a/vs-ui/src/components/GlobalAlert/GlobalAlert.scss
+++ b/vs-ui/src/components/GlobalAlert/GlobalAlert.scss
@@ -1,11 +1,11 @@
 .vs-alert {
-  position: absolute;
-  top: 0;
-  right: 0;
   display: flex;
   justify-content: space-around;
-  margin-top: 1vh;
   margin-right: 1vh;
+  margin-top: 1vh;
+  position: absolute;
+  right: 0;
+  top: 0;
   width: 40vh;
   z-index: 10;
 }

--- a/vs-ui/src/components/GlobalAlert/GlobalAlert.spec.tsx
+++ b/vs-ui/src/components/GlobalAlert/GlobalAlert.spec.tsx
@@ -1,0 +1,18 @@
+import { render } from "@testing-library/react";
+
+import { GlobalAlert } from "./GlobalAlert";
+
+describe("GlobalAlert", () => {
+  it("renders with icon", () => {
+    const { container } = render(
+      <GlobalAlert typ="warning" text="icon" icon={true} />
+    );
+    expect(container).toMatchSnapshot();
+  });
+  it("renders without an icon", () => {
+    const { container } = render(
+      <GlobalAlert typ="warning" text="no icon" icon={false} />
+    );
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/vs-ui/src/components/GlobalAlert/GlobalAlert.tsx
+++ b/vs-ui/src/components/GlobalAlert/GlobalAlert.tsx
@@ -1,0 +1,19 @@
+import { Alert } from "@trussworks/react-uswds";
+import React from "react";
+import "./GlobalAlert.scss";
+
+export type AlertType = "success" | "warning" | "error" | "info";
+
+export interface AlertProps {
+  typ: AlertType;
+  text: string;
+  icon: boolean;
+}
+
+export const GlobalAlert: React.FC<AlertProps> = (props) => {
+  return (
+    <Alert type={props.typ} noIcon={!props.icon} className="vs-alert">
+      {props.text}
+    </Alert>
+  )
+}

--- a/vs-ui/src/components/GlobalAlert/GlobalAlert.tsx
+++ b/vs-ui/src/components/GlobalAlert/GlobalAlert.tsx
@@ -15,5 +15,5 @@ export const GlobalAlert: React.FC<AlertProps> = (props) => {
     <Alert type={props.typ} noIcon={!props.icon} className="vs-alert">
       {props.text}
     </Alert>
-  )
-}
+  );
+};

--- a/vs-ui/src/components/GlobalAlert/__snapshots__/GlobalAlert.spec.tsx.snap
+++ b/vs-ui/src/components/GlobalAlert/__snapshots__/GlobalAlert.spec.tsx.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GlobalAlert renders with icon 1`] = `
+<div>
+  <div
+    class="usa-alert usa-alert--warning vs-alert"
+    data-testid="alert"
+  >
+    <div
+      class="usa-alert__body"
+    >
+      <p
+        class="usa-alert__text"
+      >
+        icon
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`GlobalAlert renders without an icon 1`] = `
+<div>
+  <div
+    class="usa-alert usa-alert--warning usa-alert--no-icon vs-alert"
+    data-testid="alert"
+  >
+    <div
+      class="usa-alert__body"
+    >
+      <p
+        class="usa-alert__text"
+      >
+        no icon
+      </p>
+    </div>
+  </div>
+</div>
+`;

--- a/vs-ui/src/providers/FhirClientProvider.tsx
+++ b/vs-ui/src/providers/FhirClientProvider.tsx
@@ -1,19 +1,59 @@
-import { useState } from "react";
+import React, { useEffect, useState } from "react";
 import Client from "fhir-kit-client";
 
 import { FhirClientContext } from "../context/FhirClientContext";
 import { OperationClient } from "../@types";
+import { AlertType, GlobalAlert } from "../components/GlobalAlert/GlobalAlert";
+
+interface ConnectionStatus {
+  text: string;
+  typ: AlertType;
+}
 
 export const FhirClientProvider: React.FC = ({ children }) => {
   const [fc] = useState(
     new Client({ baseUrl: `${process.env.REACT_APP_BACKEND_URL}/fhir` })
   );
+
+  const [status, setStatus] = useState<ConnectionStatus | null>(null);
+
+  useEffect(() => {
+    const checkConnection = async () => {
+      // Wait 3 seconds before showing a notification
+      const timer = setTimeout(() => {
+        setStatus({
+          text: "Waking the beast (May take a while)",
+          typ: "info",
+        });
+      }, 3000);
+      try {
+        await fc.capabilityStatement();
+        setStatus(null);
+      } catch (e) {
+        setStatus({
+          text: "Unable to connect to backend",
+          typ: "error",
+        });
+      } finally {
+        // When the request finishes, make sure we clear the timeout so we don't fire it later.
+        clearTimeout(timer);
+      }
+    };
+    // noinspection JSIgnoredPromiseFromCall
+    checkConnection();
+  }, [fc]);
+
   return (
     <FhirClientContext.Provider value={{ client: fc as OperationClient }}>
       <FhirClientContext.Consumer>
         {({ client }) => {
           if (client) {
-            return children;
+            return [
+              status && (
+                <GlobalAlert typ={status.typ} text={status.text} icon={true} />
+              ),
+              children,
+            ];
           }
           return "Authorizing...";
         }}


### PR DESCRIPTION
When targeting the Heroku backend, it's unclear to the user what is actually happening when it's waking from sleep

Added toast notification when waiting for the server.
We now wait 3 seconds before displaying a message that we're waiting for something to happen.
If the connection fails, we alert the user with another fancy alert.