### PR TITLE
Setup JSON logging in production

### DIFF
--- a/api-application/build.gradle
+++ b/api-application/build.gradle
@@ -66,6 +66,10 @@ dependencies {
     implementation "ca.uhn.hapi.fhir:hapi-fhir-validation:${hapiVersion}"
     implementation "ca.uhn.hapi.fhir:hapi-fhir-validation-resources-r4:${hapiVersion}"
 
+    // Logging
+    implementation 'net.logstash.logback:logstash-logback-encoder:6.6'
+    implementation 'ch.qos.logback:logback-classic'
+
     // Deployment
     implementation 'com.rollbar:rollbar-spring-boot-webmvc:1.7.6'
     implementation 'org.springframework.boot:spring-boot-starter-cache'

--- a/api-application/src/main/resources/hibernate.properties
+++ b/api-application/src/main/resources/hibernate.properties
@@ -1,0 +1,2 @@
+hibernate.types.print.banner=false
+hibernate.jdbc.time_zone=UTC

--- a/api-application/src/main/resources/logback-spring.xml
+++ b/api-application/src/main/resources/logback-spring.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <springProfile name="!heroku">
+        <include resource="org/springframework/boot/logging/logback/base.xml"/>
+    </springProfile>
+    <springProfile name="heroku">
+        <appender name="json"
+                  class="ch.qos.logback.core.ConsoleAppender">
+            <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+                <providers>
+                    <timestamp>
+                        <timeZone>UTC</timeZone>
+                    </timestamp>
+                    <pattern>
+                        <pattern>
+                            {
+                            "level": "%level",
+                            "traceId": "%X{X-B3-TraceId:-}",
+                            "spanId": "%X{X-B3-SpanId:-}",
+                            "thread": "%thread",
+                            "class": "%logger{40}",
+                            "message": "%message"
+                            }
+                        </pattern>
+                    </pattern>
+                    <stackTrace>
+                        <throwableConverter class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">
+                            <maxDepthPerThrowable>30</maxDepthPerThrowable>
+                            <maxLength>2048</maxLength>
+                            <shortenedClassNameLength>20</shortenedClassNameLength>
+                            <rootCauseFirst>true</rootCauseFirst>
+                        </throwableConverter>
+                    </stackTrace>
+                </providers>
+            </encoder>
+        </appender>
+        <root level="info">
+            <appender-ref ref="stdout"/>
+        </root>
+    </springProfile>
+</configuration>


### PR DESCRIPTION
By default, we log nicely to the console.
In production, we spew json to make indexing easier.

closes #53 