### PR TITLE
Normalize phone numbers

### DIFF
--- a/api-application/build.gradle
+++ b/api-application/build.gradle
@@ -70,6 +70,9 @@ dependencies {
     implementation 'net.logstash.logback:logstash-logback-encoder:6.6'
     implementation 'ch.qos.logback:logback-classic'
 
+    // Formatting
+    implementation 'com.googlecode.libphonenumber:libphonenumber:8.12.20'
+
     // Deployment
     implementation 'com.rollbar:rollbar-spring-boot-webmvc:1.7.6'
     implementation 'org.springframework.boot:spring-boot-starter-cache'

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/db/models/AbstractTelecomEntity.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/db/models/AbstractTelecomEntity.java
@@ -1,5 +1,6 @@
 package gov.usds.vaccineschedule.api.db.models;
 
+import gov.usds.vaccineschedule.api.formatters.PhoneFormatter;
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.DynamicUpdate;
 import org.hl7.fhir.r4.model.ContactPoint;
@@ -32,7 +33,12 @@ public class AbstractTelecomEntity<T> extends BaseEntity {
 
     protected AbstractTelecomEntity(ContactPoint.ContactPointSystem system, String value) {
         this.system = system;
-        this.value = value;
+        // If we're provided a phone number like value, format it.
+        if (shouldNormalizePhone(system)) {
+            this.value = PhoneFormatter.formatPhoneNumber(value);
+        } else {
+            this.value = value;
+        }
     }
 
     public ContactPoint.ContactPointSystem getSystem() {
@@ -53,5 +59,12 @@ public class AbstractTelecomEntity<T> extends BaseEntity {
 
     public ContactPoint toFHIR() {
         return new ContactPoint().setSystem(this.system).setValue(this.value);
+    }
+
+    private static boolean shouldNormalizePhone(ContactPoint.ContactPointSystem system) {
+        return system.equals(ContactPoint.ContactPointSystem.PHONE)
+                || system.equals(ContactPoint.ContactPointSystem.FAX)
+                || system.equals(ContactPoint.ContactPointSystem.PAGER)
+                || system.equals(ContactPoint.ContactPointSystem.SMS);
     }
 }

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/db/models/SlotEntity.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/db/models/SlotEntity.java
@@ -1,5 +1,6 @@
 package gov.usds.vaccineschedule.api.db.models;
 
+import gov.usds.vaccineschedule.api.formatters.PhoneFormatter;
 import gov.usds.vaccineschedule.common.Constants;
 import gov.usds.vaccineschedule.common.models.VaccineSlot;
 import org.hl7.fhir.r4.model.IdType;
@@ -200,7 +201,7 @@ public class SlotEntity extends UpstreamUpdateableEntity implements Flammable<Va
             entity.setBookingUrl(resource.getBookingUrl().asStringValue());
         }
         if (!resource.getBookingPhone().isEmpty()) {
-            entity.setBookingPhone(resource.getBookingPhone().getValueAsString());
+            entity.setBookingPhone(PhoneFormatter.formatPhoneNumber(resource.getBookingPhone().getValueAsString()));
         }
         if (!resource.getCapacity().isEmpty()) {
             entity.setCapacity(resource.getCapacity().getValue());

--- a/api-application/src/main/java/gov/usds/vaccineschedule/api/formatters/PhoneFormatter.java
+++ b/api-application/src/main/java/gov/usds/vaccineschedule/api/formatters/PhoneFormatter.java
@@ -1,0 +1,34 @@
+package gov.usds.vaccineschedule.api.formatters;
+
+import com.google.i18n.phonenumbers.NumberParseException;
+import com.google.i18n.phonenumbers.PhoneNumberUtil;
+import com.google.i18n.phonenumbers.Phonenumber;
+import org.springframework.stereotype.Component;
+
+/**
+ * Created by nickrobison on 4/29/21
+ */
+@Component
+public class PhoneFormatter {
+
+    private PhoneFormatter() {
+        // Not used
+    }
+
+    /**
+     * Format provided phone number according to {@link com.google.i18n.phonenumbers.PhoneNumberUtil.PhoneNumberFormat#NATIONAL} standards
+     *
+     * @param phoneNumber - {@link String} supplied phone number to parse
+     * @return - {@link String} formatted phone number
+     * @throws IllegalArgumentException if the provided phone number is invalid
+     */
+    public static String formatPhoneNumber(String phoneNumber) {
+        try {
+            final PhoneNumberUtil phoneUtil = PhoneNumberUtil.getInstance();
+            final Phonenumber.PhoneNumber parsed = phoneUtil.parse(phoneNumber, "US");
+            return phoneUtil.format(parsed, PhoneNumberUtil.PhoneNumberFormat.NATIONAL);
+        } catch (NumberParseException e) {
+            throw new IllegalArgumentException(String.format("`%s` is not a valid phone number", phoneNumber), e);
+        }
+    }
+}

--- a/api-application/src/test/java/gov/usds/vaccineschedule/api/formattters/PhoneFormatterTest.java
+++ b/api-application/src/test/java/gov/usds/vaccineschedule/api/formattters/PhoneFormatterTest.java
@@ -1,0 +1,30 @@
+package gov.usds.vaccineschedule.api.formattters;
+
+import gov.usds.vaccineschedule.api.formatters.PhoneFormatter;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Created by nickrobison on 4/29/21
+ */
+public class PhoneFormatterTest {
+
+    private static final String EXPECTED_NUMBER = "(555) 555-5555";
+
+    @Test
+    public void testCorrectFormat() {
+        assertAll(() -> assertEquals(EXPECTED_NUMBER, PhoneFormatter.formatPhoneNumber("5555555555")),
+                () -> assertEquals(EXPECTED_NUMBER, PhoneFormatter.formatPhoneNumber("555-555-5555")),
+                () -> assertEquals(EXPECTED_NUMBER, PhoneFormatter.formatPhoneNumber(EXPECTED_NUMBER)),
+                () -> assertEquals(EXPECTED_NUMBER, PhoneFormatter.formatPhoneNumber("+1 555 555-5555")));
+    }
+
+    @Test
+    public void testInvalidPhoneNumber() {
+        final IllegalArgumentException exn = assertThrows(IllegalArgumentException.class, () -> PhoneFormatter.formatPhoneNumber("Not a number"));
+        assertEquals("`Not a number` is not a valid phone number", exn.getMessage(), "Should have correct error message");
+    }
+}

--- a/api-application/src/test/java/gov/usds/vaccineschedule/api/services/TestLocationService.java
+++ b/api-application/src/test/java/gov/usds/vaccineschedule/api/services/TestLocationService.java
@@ -5,6 +5,7 @@ import ca.uhn.fhir.rest.param.TokenParam;
 import gov.usds.vaccineschedule.api.BaseApplicationTest;
 import gov.usds.vaccineschedule.common.helpers.NDJSONToFHIR;
 import gov.usds.vaccineschedule.common.models.VaccineLocation;
+import org.hl7.fhir.r4.model.ContactPoint;
 import org.hl7.fhir.r4.model.InstantType;
 import org.hl7.fhir.r4.model.Location;
 import org.hl7.fhir.r4.model.Meta;
@@ -16,8 +17,10 @@ import org.springframework.data.domain.Pageable;
 
 import java.io.InputStream;
 import java.sql.Date;
+import java.util.Collections;
 import java.util.List;
 
+import static gov.usds.vaccineschedule.api.utils.FhirHandlers.getPhoneNumber;
 import static gov.usds.vaccineschedule.common.Constants.LAST_SOURCE_SYNC;
 import static gov.usds.vaccineschedule.common.Constants.ORIGINAL_ID_SYSTEM;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -50,12 +53,15 @@ public class TestLocationService extends BaseApplicationTest {
         firstLoc.setMeta(meta);
         // Update the name and save it
         firstLoc.setName("I'm an updated name");
+        // Update the phone number as well, because libphonenumber can't handle 000 area codes
+        firstLoc.setTelecom(Collections.singletonList(new ContactPoint().setSystem(ContactPoint.ContactPointSystem.PHONE).setValue("555-000-0000")));
         service.addLocation(firstLoc);
         // Now, find it and pull back out
 
         final Location updatedLocation = service.findLocations(tokenParam, null, null, null, PageRequest.of(0, 10)).get(0);
         assertAll(() -> assertEquals(firstLoc.getName(), updatedLocation.getName(), "Should have updated name"),
-                () -> assertFalse(getCurrentTimestamp(origLocation).equalsDeep(getCurrentTimestamp(updatedLocation)), "Update timestamp should be different"));
+                () -> assertFalse(getCurrentTimestamp(origLocation).equalsDeep(getCurrentTimestamp(updatedLocation)), "Update timestamp should be different"),
+                () -> assertEquals("(555) 000-0000", getPhoneNumber(updatedLocation), "Phone number should be formatted correctly"));
     }
 
     @Test
@@ -73,5 +79,4 @@ public class TestLocationService extends BaseApplicationTest {
         final Type value = location.getMeta().getExtensionByUrl(LAST_SOURCE_SYNC).getValue();
         return value.castToInstant(value);
     }
-
 }

--- a/api-application/src/test/java/gov/usds/vaccineschedule/api/services/TestLocationService.java
+++ b/api-application/src/test/java/gov/usds/vaccineschedule/api/services/TestLocationService.java
@@ -17,7 +17,6 @@ import org.springframework.data.domain.Pageable;
 
 import java.io.InputStream;
 import java.sql.Date;
-import java.util.Collections;
 import java.util.List;
 
 import static gov.usds.vaccineschedule.api.utils.FhirHandlers.getPhoneNumber;
@@ -37,7 +36,6 @@ public class TestLocationService extends BaseApplicationTest {
 
     @Test
     void testLocationUpdate() {
-
         final IParser parser = ctx.newJsonParser();
         final NDJSONToFHIR converter = new NDJSONToFHIR(parser);
 
@@ -54,7 +52,7 @@ public class TestLocationService extends BaseApplicationTest {
         // Update the name and save it
         firstLoc.setName("I'm an updated name");
         // Update the phone number as well, because libphonenumber can't handle 000 area codes
-        firstLoc.setTelecom(Collections.singletonList(new ContactPoint().setSystem(ContactPoint.ContactPointSystem.PHONE).setValue("555-000-0000")));
+        firstLoc.setTelecom(List.of(new ContactPoint().setSystem(ContactPoint.ContactPointSystem.PHONE).setValue("555-000-0000"), new ContactPoint().setSystem(ContactPoint.ContactPointSystem.EMAIL).setValue("test@test.com")));
         service.addLocation(firstLoc);
         // Now, find it and pull back out
 

--- a/api-application/src/test/java/gov/usds/vaccineschedule/api/services/TestSlotService.java
+++ b/api-application/src/test/java/gov/usds/vaccineschedule/api/services/TestSlotService.java
@@ -7,6 +7,7 @@ import gov.usds.vaccineschedule.common.helpers.NDJSONToFHIR;
 import gov.usds.vaccineschedule.common.models.VaccineSlot;
 import org.hl7.fhir.r4.model.IntegerType;
 import org.hl7.fhir.r4.model.Meta;
+import org.hl7.fhir.r4.model.StringType;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
@@ -43,12 +44,14 @@ public class TestSlotService extends BaseApplicationTest {
         final Meta m1 = new Meta().setLastUpdated(updatedDate);
         firstSlot.setMeta(m1);
         firstSlot.setCapacity(new IntegerType(5));
+        firstSlot.setBookingPhone(new StringType("5550000000"));
         service.addSlot(firstSlot);
         final TokenParam tokenParam = new TokenParam().setSystem(ORIGINAL_ID_SYSTEM).setValue(firstSlot.getId());
         final VaccineSlot updatedSlot = (VaccineSlot) service.findSlotsWithId(tokenParam, PageRequest.of(0, 10), true).get(0);
         assertAll(() -> assertTrue(firstSlot.getCapacity().equalsDeep(updatedSlot.getCapacity()), "Should have updated capacity"),
-                () -> assertTrue(firstSlot.getBookingPhone().equalsDeep(updatedSlot.getBookingPhone()), "Should have original phone number"),
+                () -> assertTrue(firstSlot.getBookingUrl().equalsDeep(updatedSlot.getBookingUrl()), "Should have original url"),
                 () -> assertEquals(updatedDate, updatedSlot.getMeta().getLastUpdated(), "Should have updated upstream"),
+                () -> assertEquals("(555) 000-0000", updatedSlot.getBookingPhone().getValue(), "Should have updated phone number"),
                 () -> assertNotNull(updatedSlot.getExtensionByUrl(FOR_LOCATION), "Should have location extension"));
     }
 

--- a/api-application/src/test/java/gov/usds/vaccineschedule/api/utils/FhirHandlers.java
+++ b/api-application/src/test/java/gov/usds/vaccineschedule/api/utils/FhirHandlers.java
@@ -5,6 +5,8 @@ import gov.usds.vaccineschedule.common.models.VaccineLocation;
 import gov.usds.vaccineschedule.common.models.VaccineSlot;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.ContactPoint;
+import org.hl7.fhir.r4.model.Location;
 import org.hl7.fhir.r4.model.Resource;
 import org.junit.jupiter.api.Assertions;
 
@@ -35,10 +37,17 @@ public class FhirHandlers {
         return resources;
     }
 
+    @SuppressWarnings("OptionalGetWithoutIsPresent")
+    public static String getPhoneNumber(Location location) {
+        return location.getTelecom().stream()
+                .filter(t -> t.getSystem().equals(ContactPoint.ContactPointSystem.PHONE))
+                .map(ContactPoint::getValue).findAny()
+                .get();
+    }
+
     private static void assertBundleUpdatedBefore(Bundle bundle, Date searchTime) {
         if (!bundle.getEntry().isEmpty()) {
             Assertions.assertTrue(bundle.getMeta().getLastUpdatedElement().before(searchTime), "Updated value should be before search time");
         }
-
     }
 }


### PR DESCRIPTION
Add `libphonenumber` to normalize to a common format.

The `LocationEntity` and `SlotEntity` classes now normalize before storing in the database.

This PR doesn't include any post-hoc handling of existing records.
Whatever's in the database will be normalized the next time we sync and given that what we have in the DB is already correct, that seems like a fair tradeoff to the complexity of handling the migration.

closes #55 