### PR TITLE
Use dependabot with Yarn

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
     directory: /
     schedule:
       interval: daily
+  - package-ecosystem: npm
+    directory: /vs-ui
+    schedule:
+      interval: daily


### PR DESCRIPTION
Use dependabot to keep our JS dependencies up to date.